### PR TITLE
refactor: apple-inspired chat experience

### DIFF
--- a/docs/client-request-flow.md
+++ b/docs/client-request-flow.md
@@ -1,0 +1,44 @@
+# Client Request Flow
+
+This document describes how a chat message travels through the Eco frontend once a person interacts with the chat UI. It covers the primary client-side responsibilities, how we enrich a message with contextual data, and the way we authenticate and deliver the request to the backend.
+
+## High-level steps
+
+1. **User input captured in the chat UI.** `ChatPage` validates and stages the message, displaying it immediately in the conversation so the interface feels responsive.【F:src/pages/ChatPage.tsx†L203-L276】
+2. **Message is persisted in Supabase.** We call `salvarMensagem`, which inserts the payload into the `mensagem` table through the shared Supabase client, guaranteeing the conversation history is stored before any external calls happen.【F:src/pages/ChatPage.tsx†L218-L224】【F:src/api/mensagem.ts†L4-L27】【F:src/lib/supabaseClient.ts†L1-L6】
+3. **Contextual memories are fetched.** In parallel we ask two memory endpoints (`/memorias/similares_v2` with fallback and `/memorias` filtered by tags) to recover relevant memories that will accompany the prompt. Both helpers reuse the shared Axios instance so that authentication headers and error handling stay consistent.【F:src/pages/ChatPage.tsx†L224-L268】【F:src/api/memoriaApi.ts†L204-L319】
+4. **Supabase session token is attached automatically.** Every request made through `api` pulls the current Supabase session and injects its bearer token, enabling backend Row Level Security (RLS) without forcing each caller to repeat that logic.【F:src/api/axios.ts†L1-L25】
+5. **Prompt is delivered to the Eco backend.** Once the prompt has been assembled with system hints, contextual memories, and the last user turns, `enviarMensagemParaEco` posts it to `/ask-eco`. The helper normalises payloads, validates responses, and surfaces backend errors in a user-friendly way.【F:src/pages/ChatPage.tsx†L261-L292】【F:src/api/ecoApi.ts†L15-L60】
+6. **UI updates with the assistant reply.** The returned text is rendered in the chat window, any structured metadata emitted by the backend is parsed, and telemetry events track the exchange.【F:src/pages/ChatPage.tsx†L274-L292】
+
+## Mermaid sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ChatUI as ChatPage (React)
+    participant SupabaseDB as Supabase (mensagem)
+    participant MemoryAPI as Memory service
+    participant EcoAPI as Eco backend
+
+    User->>ChatUI: Submit message
+    ChatUI->>SupabaseDB: salvarMensagem()
+    ChatUI->>MemoryAPI: buscarMemoriasSemelhantesV2()
+    ChatUI->>MemoryAPI: buscarUltimasMemoriasComTags()
+    Note over ChatUI,MemoryAPI: Axios interceptor adds Supabase bearer token
+    ChatUI->>EcoAPI: enviarMensagemParaEco()/ask-eco
+    EcoAPI-->>ChatUI: Assistant reply + metadata
+    ChatUI-->>User: Render response & telemetry
+```
+
+## Authentication touchpoints
+
+- Supabase credentials (`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`) initialise the singleton client used for both direct Supabase CRUD operations and session retrieval.【F:src/lib/supabaseClient.ts†L1-L6】
+- The Axios instance (`api`) centralises the API base URL, credentials policy, and Supabase bearer injection. Any new client-side request should reuse this instance to inherit the existing authentication behaviour.【F:src/api/axios.ts†L5-L25】
+
+## Error handling strategy
+
+- Memory helper utilities map server responses to a canonical shape, falling back between v2 and v1 endpoints and translating HTTP failures into actionable error messages.【F:src/api/memoriaApi.ts†L201-L319】
+- `enviarMensagemParaEco` decorates backend errors with HTTP details so the chat UI can surface meaningful feedback and log issues for observability.【F:src/api/ecoApi.ts†L32-L59】
+
+By following this flow the client ensures that every outbound request is authenticated, contextualised, and recoverable while keeping the user interface responsive.

--- a/index.html
+++ b/index.html
@@ -18,18 +18,10 @@
 
     <title>ECO - Espelho Emocional e Comportamental</title>
 
-    <!--
-      Se quiser manter Inter como fallback via CDN, descomente abaixo.
-      A stack do Tailwind já inclui Inter; em macOS/iOS, SF Pro será usada.
-    -->
-    <!--
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
-    -->
+    <link rel="preconnect" href="https://ecobackend888.onrender.com" crossorigin />
+    <link rel="dns-prefetch" href="https://ecobackend888.onrender.com" />
+    <link rel="preconnect" href="https://supabase.co" crossorigin />
+    <link rel="dns-prefetch" href="https://supabase.co" />
 
     <!-- Helpers: --vh para 100vh e feature flag de backdrop-filter -->
     <script>
@@ -55,14 +47,9 @@
       html, body, #root { height: 100%; }
       body {
         margin: 0;
-        /* usa sua util bg-eco-vibe também no body para evitar flash branco */
-        background:
-          radial-gradient(1200px 600px at 20% -10%, #E9E8FF, transparent 55%),
-          radial-gradient(900px 600px at 85% -5%, #FFE7E1, transparent 60%),
-          linear-gradient(120deg, #EEF3FF 0%, #FFF8F3 70%);
-        color: #0f172a; /* slate-900 */
+        background: #ffffff;
+        color: #0f172a;
       }
-      /* fallback p/ browsers sem svh: 100*var(--vh) */
       .min-h-viewport {
         min-height: calc(var(--vh, 1vh) * 100);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.15.24",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
@@ -61,13 +64,22 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.11",
         "globals": "^15.9.0",
+        "jsdom": "^25.0.0",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.3.0",
         "vite": "^5.4.10",
-        "vite-plugin-string": "^1.2.3"
+        "vite-plugin-string": "^1.2.3",
+        "vitest": "^2.1.3"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -81,6 +93,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -371,6 +404,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dimforge/rapier3d-compat": {
@@ -3802,6 +3950,96 @@
         "@supabase/storage-js": "2.12.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -3816,6 +4054,14 @@
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
       "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4446,6 +4692,129 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@wavesurfer/react": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@wavesurfer/react/-/react-1.0.11.tgz",
@@ -4604,6 +4973,26 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -4853,6 +5242,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4942,6 +5341,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4997,6 +5413,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -5253,6 +5679,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5265,6 +5698,27 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -5457,6 +5911,57 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -5484,6 +5989,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -5501,6 +6013,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -5578,6 +6100,14 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5688,6 +6218,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -5705,6 +6248,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -6018,6 +6568,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/express": {
       "version": "5.1.0",
@@ -6755,6 +7315,19 @@
       "integrity": "sha512-Pz+7IzvkbAht/zXvwLzA/stUHNqztqKvlLbfpq6ZYU68+gZ+CZMlsbQBPUviRap+3IQ41E39ke7Ia+yvhsehEQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -6902,6 +7475,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -7070,6 +7653,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -7146,6 +7736,98 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -7341,6 +8023,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7360,6 +8049,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/maath": {
       "version": "0.10.8",
       "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
@@ -7368,6 +8068,16 @@
       "peerDependencies": {
         "@types/three": ">=0.134.0",
         "three": ">=0.134.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -8055,6 +8765,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -8225,6 +8945,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8371,6 +9098,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8438,6 +9178,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -8643,6 +9400,55 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
@@ -9103,6 +9909,20 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -9272,6 +10092,13 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9321,6 +10148,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.21.0",
@@ -9477,6 +10317,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -9508,6 +10355,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stats-gl": {
       "version": "2.4.2",
@@ -9543,6 +10397,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -9686,6 +10547,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9780,6 +10654,13 @@
       "peerDependencies": {
         "react": ">=17.0"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
@@ -9927,6 +10808,70 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9947,6 +10892,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -10462,6 +11420,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-string": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/vite-plugin-string/-/vite-plugin-string-1.2.3.tgz",
@@ -10473,6 +11454,85 @@
       },
       "peerDependencies": {
         "vite": ">=2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/warning": {
@@ -10516,6 +11576,29 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -10539,6 +11622,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -10672,6 +11772,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@google-cloud/language": "^7.0.2",
@@ -57,18 +58,23 @@
     "@types/react-dom": "^18.3.0",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.6.1",
     "autoprefixer": "^10.4.18",
     "dotenv": "^16.5.0",
     "eslint": "^9.9.1",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "jsdom": "^25.0.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.10",
-    "vite-plugin-string": "^1.2.3"
+    "vite-plugin-string": "^1.2.3",
+    "vitest": "^2.1.3"
   },
   "resolutions": {
     "react": "18.3.1",

--- a/src/components/EcoBubbleIcon.tsx
+++ b/src/components/EcoBubbleIcon.tsx
@@ -1,25 +1,27 @@
 import React from 'react';
 
 type Props = {
-  size?: number;        // px (default 24)
-  className?: string;   // para escalas/responsivo
+  size?: number;
+  className?: string;
 };
 
 const EcoBubbleIcon: React.FC<Props> = ({ size = 24, className }) => {
   return (
-    <div
-      className={`rounded-full shadow-md ring-1 ring-[rgba(200,220,255,0.45)] ${className || ''}`}
+    <span
+      aria-hidden
+      className={className}
       style={{
+        display: 'inline-flex',
         width: size,
         height: size,
+        borderRadius: '999px',
         background:
-          'radial-gradient(circle at 30% 30%, rgba(255,255,255,0.88), rgba(240,240,255,0.45))',
-        border: '1px solid rgba(200, 220, 255, 0.45)',
-        boxShadow: '0 6px 18px rgba(0, 0, 0, 0.10)', // presença um pouco maior
-        backdropFilter: 'blur(8px)',
-        WebkitBackdropFilter: 'blur(8px)',
+          'radial-gradient(120% 120% at 30% 20%, rgba(255,255,255,0.95), rgba(226,232,240,0.45)), linear-gradient(160deg, rgba(255,255,255,0.85), rgba(209,213,219,0.55))',
+        border: '1px solid rgba(255,255,255,0.7)',
+        boxShadow: '0 6px 18px rgba(15,23,42,0.12), inset 0 1px 0 rgba(255,255,255,0.65)',
+        backdropFilter: 'blur(12px)',
+        WebkitBackdropFilter: 'blur(12px)',
       }}
-      aria-hidden
     />
   );
 };

--- a/src/components/TourInicial.tsx
+++ b/src/components/TourInicial.tsx
@@ -1,5 +1,6 @@
 // src/components/TourInicial.tsx
 import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import GlassBubble from './GlassBubble';
@@ -30,7 +31,7 @@ const TourInicial: React.FC<TourInicialProps> = ({ onClose }) => {
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
-  return (
+  const modalContent = (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
       style={{ background: '#ffffff' }} // 🔒 fundo branco puro
@@ -97,6 +98,12 @@ const TourInicial: React.FC<TourInicialProps> = ({ onClose }) => {
       </motion.div>
     </div>
   );
+
+  if (typeof document === 'undefined') {
+    return modalContent;
+  }
+
+  return createPortal(modalContent, document.body);
 };
 
 export default TourInicial;

--- a/src/components/TypingDots.tsx
+++ b/src/components/TypingDots.tsx
@@ -1,85 +1,51 @@
 // TypingDots.tsx
-import React from "react";
-import { motion } from "framer-motion";
+import React, { memo } from 'react';
+import { motion } from 'framer-motion';
 
-type Variant = "pill" | "bubble" | "inline";
+type Variant = 'pill' | 'bubble' | 'inline';
+type Size = 'sm' | 'md' | 'lg';
+
 type Props = {
   variant?: Variant;
-  size?: "sm" | "md" | "lg";
+  size?: Size;
   className?: string;
 };
 
-const SIZES = {
-  sm: { dot: 6, gap: 6, padX: 8, padY: 6, radius: "rounded-xl" },
-  md: { dot: 8, gap: 8, padX: 12, padY: 8, radius: "rounded-2xl" },
-  lg: { dot: 10, gap: 10, padX: 14, padY: 10, radius: "rounded-3xl" },
+const SIZES: Record<Size, { dot: number; gap: number; padX: number; padY: number; radius: string }> = {
+  sm: { dot: 6, gap: 6, padX: 8, padY: 6, radius: 'rounded-xl' },
+  md: { dot: 8, gap: 8, padX: 12, padY: 8, radius: 'rounded-2xl' },
+  lg: { dot: 10, gap: 10, padX: 16, padY: 10, radius: 'rounded-3xl' },
 };
 
 const dotTransition = {
   repeat: Infinity,
-  ease: [0.22, 1, 0.36, 1], // iOS-like
+  ease: [0.22, 1, 0.36, 1],
   duration: 1.2,
 };
 
-const TypingDots: React.FC<Props> = ({
-  variant = "pill",
-  size = "md",
-  className = "",
-}) => {
+const TypingDotsComponent: React.FC<Props> = ({ variant = 'pill', size = 'md', className = '' }) => {
   const s = SIZES[size];
 
-  const baseDots = (
-    <>
-      {[0, 0.2, 0.4].map((delay, i) => (
-        <motion.span
-          key={i}
-          role="presentation"
-          className="inline-block rounded-full bg-slate-400/70 dark:bg-slate-300/70"
-          style={{ width: s.dot, height: s.dot }}
-          animate={{ y: [0, -3, 0], opacity: [0.7, 1, 0.7] }}
-          transition={{ ...dotTransition, delay }}
-        />
-      ))}
-    </>
-  );
+  const dots = [0, 0.18, 0.36].map((delay, i) => (
+    <motion.span
+      key={i}
+      role="presentation"
+      className="inline-block rounded-full bg-[rgba(100,116,139,0.75)]"
+      style={{ width: s.dot, height: s.dot }}
+      animate={{ y: [0, -3, 0], opacity: [0.45, 1, 0.45] }}
+      transition={{ ...dotTransition, delay }}
+    />
+  ));
 
-  // Container styles por variante
   const containers: Record<Variant, string> = {
-    pill: `
-      inline-flex items-center
-      px-[${s.padX}px] py-[${s.padY}px] ${s.radius}
-      gap-[${s.gap}px]
-      bg-white/65 dark:bg-white/10
-      backdrop-blur-md
-      border border-white/40 dark:border-white/15
-      shadow-[inset_0_1px_0_rgba(255,255,255,0.6),0_8px_24px_rgba(0,0,0,0.06)]
-    `,
-    bubble: `
-      inline-flex items-center
-      px-[${s.padX}px] py-[${s.padY}px] rounded-full
-      gap-[${s.gap}px]
-      bg-[radial-gradient(120%_120%_at_30%_30%,rgba(255,255,255,0.9),rgba(255,255,255,0.55))]
-      dark:bg-[radial-gradient(120%_120%_at_30%_30%,rgba(255,255,255,0.15),rgba(255,255,255,0.06))]
-      backdrop-blur-xl
-      border border-white/50 dark:border-white/10
-      shadow-[0_10px_30px_rgba(0,0,0,0.08)]
-      ring-1 ring-black/5
-    `,
-    inline: `
-      inline-flex items-center gap-[${s.gap}px]
-      align-middle
-    `,
+    pill: `inline-flex items-center gap-[${s.gap}px] px-[${s.padX}px] py-[${s.padY}px] ${s.radius}
+      bg-[color-mix(in_srgb,var(--surface)_88%,transparent)] backdrop-blur-lg border border-[rgba(255,255,255,0.65)]
+      shadow-[var(--shadow-xs)] text-[color:var(--muted)]`,
+    bubble: `inline-flex items-center gap-[${s.gap}px] px-[${s.padX}px] py-[${s.padY}px] rounded-full
+      bg-[color-mix(in_srgb,var(--surface-strong)_90%,transparent)] backdrop-blur-xl border border-[rgba(255,255,255,0.75)]
+      shadow-[var(--shadow-xs)] text-[color:var(--muted)]`,
+    inline: `inline-flex items-center gap-[${s.gap}px] align-middle`,
   };
-
-  // Halo suave (apenas para pill e bubble)
-  const Halo = () =>
-    variant === "inline" ? null : (
-      <span
-        aria-hidden
-        className="absolute inset-0 -z-10 rounded-[inherit] blur-xl opacity-50
-                   bg-[radial-gradient(60%_60%_at_50%_10%,#EEF2FF,transparent_70%)] dark:opacity-20"
-      />
-    );
 
   return (
     <div
@@ -88,13 +54,11 @@ const TypingDots: React.FC<Props> = ({
       aria-label="Eco está digitando"
       role="status"
     >
-      <Halo />
-      {/* reduz animação para quem prefere menos movimento */}
-      <div className="motion-reduce:animate-none motion-reduce:[&_*]:transition-none flex items-center gap-[inherit]">
-        {baseDots}
+      <div className="flex items-center gap-[inherit] motion-reduce:animate-none motion-reduce:[&_*]:transition-none">
+        {dots}
       </div>
     </div>
   );
 };
 
-export default TypingDots;
+export default memo(TypingDotsComponent);

--- a/src/components/ui/Primitives.tsx
+++ b/src/components/ui/Primitives.tsx
@@ -1,0 +1,72 @@
+import React, { forwardRef } from 'react';
+import clsx from 'clsx';
+
+type SurfaceCardProps = React.HTMLAttributes<HTMLDivElement>;
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'subtle';
+};
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+type ToolbarProps = React.HTMLAttributes<HTMLElement>;
+
+type ChipProps = React.HTMLAttributes<HTMLSpanElement> & {
+  active?: boolean;
+};
+
+export const SurfaceCard = forwardRef<HTMLDivElement, SurfaceCardProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={clsx('surface-card', className)} {...props} />
+  )
+);
+SurfaceCard.displayName = 'SurfaceCard';
+
+export const GlassToolbar = forwardRef<HTMLElement, ToolbarProps>(
+  ({ className, ...props }, ref) => (
+    <header
+      ref={ref}
+      className={clsx('surface-toolbar', className)}
+      {...props}
+    />
+  )
+);
+GlassToolbar.displayName = 'GlassToolbar';
+
+export const GlassButton = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', disabled, ...props }, ref) => (
+    <button
+      ref={ref}
+      data-variant={variant}
+      className={clsx(
+        'surface-button',
+        variant === 'subtle' && 'surface-button--subtle',
+        disabled && 'surface-button--disabled',
+        className
+      )}
+      disabled={disabled}
+      {...props}
+    />
+  )
+);
+GlassButton.displayName = 'GlassButton';
+
+export const InputField = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input ref={ref} className={clsx('surface-input', className)} {...props} />
+  )
+);
+InputField.displayName = 'InputField';
+
+export const Chip = forwardRef<HTMLSpanElement, ChipProps>(
+  ({ className, active = false, ...props }, ref) => (
+    <span
+      ref={ref}
+      data-active={active ? 'true' : undefined}
+      className={clsx('surface-chip', active && 'surface-chip--active', className)}
+      {...props}
+    />
+  )
+);
+Chip.displayName = 'Chip';
+

--- a/src/index.css
+++ b/src/index.css
@@ -2,480 +2,496 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Evita “font boosting” no iOS/Android e melhora renderização */
-html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; text-rendering: optimizeLegibility; }
-
-body {
-  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  background-color: #ffffff;
-  background-image: none;
-  overflow: hidden;              /* scroll vive no container do chat */
-  overscroll-behavior-y: none;   /* remove bounce do body */
-  font-feature-settings: "kern","liga","calt";
-  font-variant-numeric: tabular-nums;
-  letter-spacing: .01em;
-}
-
-/* ---------------------------- Tokens ---------------------------- */
 :root {
-  --cerulean-blue: #ffffff; /* ← agora branco */
-  --rose-quartz:   #ffffff; /* ← agora branco */
-  --bg-cream: #ffffff;
-
-  --app-vignette: radial-gradient(1200px 800px at 50% -10%, rgba(0,0,0,0.04), transparent 70%);
-  --app-texture: url("data:image/svg+xml;utf8,\
-    <svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill-opacity='0.03'>\
-      <rect width='100' height='100' fill='white'/>\
-      <circle cx='1' cy='1' r='1' fill='black'/>\
-    </svg>");
-
-  --eco-bubble-gradient: linear-gradient(135deg, #a1c4fd, #c2e9fb);
-
-  --vh: 1vh;
-
-  --inset-bottom: 0px;
-  --safe-top:    env(safe-area-inset-top, 0px);
-  --safe-right:  env(safe-area-inset-right, 0px);
+  color-scheme: light;
+  --bg: #ffffff;
+  --ink: #111827;
+  --ink-soft: rgba(17, 24, 39, 0.78);
+  --muted: #64748b;
+  --ring-soft: rgba(0, 0, 0, 0.1);
+  --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --shadow-lg: 0 4px 24px rgba(15, 23, 42, 0.08);
+  --surface: rgba(255, 255, 255, 0.68);
+  --surface-strong: rgba(255, 255, 255, 0.82);
+  --surface-border: rgba(255, 255, 255, 0.7);
+  --surface-border-strong: rgba(255, 255, 255, 0.82);
+  --surface-divider: rgba(15, 23, 42, 0.06);
+  --surface-highlight: rgba(255, 255, 255, 0.55);
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
-  --safe-left:   env(safe-area-inset-left, 0px);
-
-  /* intensidades do vidro (ajustadas p/ fundo branco) */
-  --glass-bg: rgba(255,255,255,0.10);
-  --glass-bg-strong: rgba(255,255,255,0.20);
-  --glass-border: rgba(0,0,0,0.06);
-  --glass-shadow: 0 8px 24px rgba(0,0,0,0.08);
-
-  /* bolhas (user agora neutra, sem verde) */
-  --bubble-eco-bg:  rgba(255,255,255,0.60);
-  --bubble-user-bg: rgba(255,255,255,0.55);
-  --bubble-border:  rgba(15,23,42,0.10);
-  --bubble-shadow:  0 3px 10px rgba(15,23,42,0.06);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --chat-padding-inline: clamp(1rem, 3vw, 1.5rem);
+  --max-chat-width: 880px;
 }
 
-/* Dark pronto (opcional) */
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg-cream: #0b0f19;
-    --glass-bg: rgba(18,22,34,.35);
-    --glass-bg-strong: rgba(18,22,34,.55);
-    --glass-border: rgba(255,255,255,.08);
-    --bubble-eco-bg: rgba(255,255,255,.10);
-    --bubble-user-bg: rgba(255,255,255,.08);
-    --bubble-border: rgba(255,255,255,.10);
+    color-scheme: dark;
+    --bg: #0b0f19;
+    --ink: #e2e8f0;
+    --ink-soft: rgba(226, 232, 240, 0.74);
+    --muted: #94a3b8;
+    --ring-soft: rgba(148, 163, 184, 0.25);
+    --surface: rgba(15, 23, 42, 0.65);
+    --surface-strong: rgba(15, 23, 42, 0.72);
+    --surface-border: rgba(148, 163, 184, 0.18);
+    --surface-border-strong: rgba(148, 163, 184, 0.26);
+    --surface-divider: rgba(148, 163, 184, 0.14);
+    --surface-highlight: rgba(148, 163, 184, 0.35);
   }
-  body { background-color: var(--bg-cream); color: #e5e7eb; }
 }
 
-/* Alto contraste / menos transparência */
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: 'kern', 'liga', 'calt';
+  font-variant-numeric: tabular-nums;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  min-height: 0;
+}
+
+body {
+  margin: 0;
+  font-family: 'SF Pro Text', 'SF Pro Display', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.65;
+  letter-spacing: 0.01em;
+  background-color: var(--bg);
+  color: var(--ink);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow: hidden;
+  overscroll-behavior-y: none;
+}
+
+body.keyboard-open {
+  overscroll-behavior-y: contain;
+  padding-bottom: var(--safe-bottom);
+}
+
+* {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button,
+[role='button'],
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+:where(button, [role='button'], a):focus-visible,
+:where(input, textarea, select):focus-visible {
+  outline: 2px solid var(--ring-soft);
+  outline-offset: 2px;
+}
+
+@supports (height: 100svh) {
+  html,
+  body,
+  #root {
+    height: 100svh;
+  }
+}
+
+@supports (height: 100dvh) {
+  html,
+  body,
+  #root {
+    height: 100dvh;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Reusable glass primitives                                          */
+/* ------------------------------------------------------------------ */
+.surface-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  border-radius: 28px;
+  background: var(--surface);
+  backdrop-filter: saturate(1.1) blur(24px);
+  -webkit-backdrop-filter: saturate(1.1) blur(24px);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-xs), var(--shadow-lg);
+  color: var(--ink);
+}
+
+.surface-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.9;
+}
+
+.surface-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: calc(var(--safe-top) + 0.75rem) var(--chat-padding-inline) 0.75rem;
+  background: color-mix(in srgb, var(--surface-strong) 80%, transparent);
+  backdrop-filter: saturate(1.05) blur(18px);
+  -webkit-backdrop-filter: saturate(1.05) blur(18px);
+  border-bottom: 1px solid var(--surface-border-strong);
+  box-shadow: var(--shadow-xs);
+  gap: 0.75rem;
+}
+
+.surface-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  padding: 0.6rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.2;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.65));
+  color: var(--ink);
+  box-shadow: var(--shadow-xs);
+  transition: transform 0.18s ease, box-shadow 0.24s ease, background 0.24s ease;
+}
+
+.surface-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-xs), 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.surface-button:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.surface-button--subtle {
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  border-color: rgba(255, 255, 255, 0.55);
+  font-weight: 500;
+}
+
+.surface-button--disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.surface-input {
+  width: 100%;
+  height: 48px;
+  border-radius: 18px;
+  padding: 0 1rem;
+  border: 1px solid var(--surface-border);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.6));
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), var(--shadow-xs);
+  color: var(--ink);
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.surface-input::placeholder {
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+
+.surface-input:focus-visible {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.95), 0 0 0 4px rgba(59, 130, 246, 0.12);
+}
+
+.surface-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), var(--shadow-xs);
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.surface-chip--active {
+  border-color: rgba(59, 130, 246, 0.35);
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.95), var(--shadow-xs), 0 14px 24px rgba(15, 23, 42, 0.1);
+}
+
+/* ------------------------------------------------------------------ */
+/* Chat layout tokens                                                 */
+/* ------------------------------------------------------------------ */
+.chat-page {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: radial-gradient(140% 110% at 50% -10%, rgba(148, 163, 184, 0.08), transparent 60%),
+    radial-gradient(120% 100% at 10% 10%, rgba(96, 165, 250, 0.08), transparent 50%),
+    var(--bg);
+}
+
+.chat-scroller {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  padding-inline: var(--chat-padding-inline);
+  padding-bottom: calc(96px + var(--safe-bottom));
+  scrollbar-gutter: stable both-edges;
+  -webkit-overflow-scrolling: touch;
+}
+
+.no-scrollbar {
+  scrollbar-width: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.message-list {
+  position: relative;
+  width: min(100%, var(--max-chat-width));
+  margin-inline: auto;
+  padding-block: 1rem 2rem;
+}
+
+.message-bubble {
+  position: relative;
+  display: inline-flex;
+  max-width: min(100%, 640px);
+  padding: 0.85rem 1rem;
+  border-radius: 22px;
+  line-height: 1.6;
+  font-size: 0.96rem;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.75);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9), var(--shadow-xs);
+  color: var(--ink);
+  backdrop-filter: saturate(1.15) blur(16px);
+  -webkit-backdrop-filter: saturate(1.15) blur(16px);
+  transition: transform 0.18s ease;
+}
+
+.message-bubble[data-role='user'] {
+  justify-self: flex-end;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.6));
+}
+
+.message-bubble[data-role='eco'] {
+  justify-self: flex-start;
+}
+
+.message-row {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) 40px;
+  align-items: flex-start;
+  gap: 0.85rem;
+  min-height: 0;
+}
+
+.message-row[data-virtual='true'] {
+  position: absolute;
+  inset-inline: 0;
+}
+
+.message-row[data-virtual='false'] {
+  position: relative;
+  margin-bottom: 1.1rem;
+}
+
+.message-row__spacer {
+  width: 32px;
+  height: 32px;
+}
+
+.message-markdown {
+  font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+}
+
+.typing-bubble {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  box-shadow: var(--shadow-xs);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.composer-shell {
+  position: sticky;
+  bottom: 0;
+  z-index: 40;
+  padding: 0.75rem var(--chat-padding-inline) calc(var(--safe-bottom) + 0.75rem);
+  background: color-mix(in srgb, var(--surface-strong) 88%, transparent);
+  backdrop-filter: saturate(1.05) blur(18px);
+  -webkit-backdrop-filter: saturate(1.05) blur(18px);
+  border-top: 1px solid var(--surface-border-strong);
+  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.06);
+}
+
+.composer-content {
+  width: min(100%, var(--max-chat-width));
+  margin-inline: auto;
+}
+
+.quick-row {
+  display: flex;
+  gap: 0.5rem;
+  padding-bottom: 0.75rem;
+}
+
+.scroll-to-bottom {
+  position: sticky;
+  bottom: 120px;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+}
+
+.scroll-to-bottom button {
+  pointer-events: auto;
+}
+
+/* ------------------------------------------------------------------ */
+/* Misc                                                               */
+/* ------------------------------------------------------------------ */
+.noise-overlay::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" fill="none"%3E%3Cpath fill="rgba(15,23,42,0.045)" d="M0 .5h.5v.5H0z"/%3E%3C/svg%3E');
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+::selection {
+  background: rgba(148, 163, 184, 0.26);
+}
+
+@media (hover: hover) {
+  .message-bubble:hover {
+    transform: translateY(-1px);
+  }
+}
+
 @media (prefers-contrast: more) {
-  .glass, .glass-strong, .glass-panel,
-  .message-eco, .message-user {
+  .surface-card,
+  .surface-toolbar,
+  .surface-button,
+  .surface-input,
+  .surface-chip,
+  .composer-shell,
+  .message-bubble,
+  .typing-bubble {
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
     background: #ffffff !important;
-    border-color: rgba(0,0,0,.18) !important;
+    border-color: rgba(0, 0, 0, 0.18) !important;
+    box-shadow: var(--shadow-xs) !important;
   }
 }
-
-/* ------------------------- Altura raiz ------------------------- */
-html, body, #root { height: 100%; min-height: 0; }
-@supports (height: 100svh) { html, body, #root { height: 100svh; } }
-@supports (height: 100dvh) { html, body, #root { height: 100dvh; } }
-
-.fit-viewport { height: 100svh; }
-@supports (height: 100dvh) { .fit-viewport { height: 100dvh; } }
-.safe-pads { padding: var(--safe-top) var(--safe-right) var(--safe-bottom) var(--safe-left); }
-
-/* --------------------------- Layout ---------------------------- */
-.app-shell {
-  height: 100%;
-  min-height: 0;
-  display: flex;
-  flex-direction: row;
-}
-
-.chat-page {
-  flex: 1 1 auto;
-  min-width: 0;
-  height: 100%;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  background: #fff;
-}
-
-/* Contêiner de rolagem do chat */
-.chat-scroller {
-  -webkit-overflow-scrolling: touch;
-  overscroll-behavior-y: contain;
-  height: 100%;
-  min-height: 0;
-  overflow-y: auto;
-  scroll-behavior: auto;     /* usamos scrollIntoView no JS */
-  overflow-anchor: none;     /* evita “pulos” */
-  touch-action: pan-y;
-  scrollbar-gutter: stable both-edges;
-}
-.anchor-end { overflow-anchor: auto; }
-
-.sticky { will-change: transform; }
-.supports-backdrop .bg-white\/80 { transform: translateZ(0); }
-
-/* ---------------------- Glass utilities ----------------------- */
-.glass {
-  background: var(--glass-bg);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-  border: 1px solid var(--glass-border);
-  box-shadow: var(--glass-shadow);
-}
-.glass-strong {
-  background: var(--glass-bg-strong);
-  backdrop-filter: blur(22px);
-  -webkit-backdrop-filter: blur(22px);
-  border: 1px solid var(--glass-border);
-  box-shadow: 0 10px 28px rgba(0,0,0,0.10);
-}
-
-.glass-panel{
-  background: rgba(255,255,255,0.6);
-  backdrop-filter: saturate(1.1) blur(14px);
-  -webkit-backdrop-filter: saturate(1.1) blur(14px);
-  border: 1px solid var(--glass-border);
-  border-radius: 16px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.08);
-  position: relative;
-}
-.glass-panel::before{
-  content:"";
-  position:absolute; inset:0;
-  border-radius: inherit;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.65);
-  pointer-events:none;
-}
-
-/* Botões “glass” */
-.glass-button{
-  background: rgba(255,255,255,0.55);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border: 1px solid var(--glass-border);
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
-  color:#111827;
-}
-.glass-button:hover{ background: rgba(255,255,255,0.7); }
-
-.glass-button-primary{
-  background: #265F77;
-  color:#fff;
-  border: 1px solid rgba(0,0,0,0.08);
-  box-shadow: 0 4px 14px rgba(38,95,119,0.25);
-}
-.glass-button-primary:hover{ filter: brightness(0.96); }
-
-.glass-popover{
-  background: rgba(255,255,255,0.7);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid var(--glass-border);
-  border-radius: 12px;
-  box-shadow: 0 12px 28px rgba(0,0,0,0.12);
-  padding: .5rem;
-}
-
-.glass-textarea{ color:#111827; }
-.glass-textarea::placeholder{
-  font-size: 0.95rem; font-weight: 450; letter-spacing: .01em;
-  color: #64748b; opacity: .95;
-}
-
-.tint-teal   { background: rgba(13,148,136,0.10); border-color: rgba(13,148,136,0.25); }
-.tint-violet { background: rgba(139,92,246,0.10); border-color: rgba(139,92,246,0.25); }
-.tint-gray   { background: rgba(255,255,255,0.10); border-color: rgba(0,0,0,0.06); }
 
 @supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
-  .glass, .glass-strong, .glass-panel, .glass-button, .glass-popover,
-  .tint-teal, .tint-violet, .tint-gray,
-  .message-eco, .message-user {
-    background: rgba(255,255,255,0.92) !important;
-    border-color: rgba(0,0,0,0.06) !important;
-    box-shadow: 0 6px 16px rgba(0,0,0,0.06) !important;
-    -webkit-backdrop-filter: none !important;
-    backdrop-filter: none !important;
+  .surface-card,
+  .surface-toolbar,
+  .surface-button,
+  .surface-input,
+  .surface-chip,
+  .composer-shell,
+  .message-bubble,
+  .typing-bubble {
+    background: #ffffff;
+    border-color: rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-xs);
   }
 }
 
-/* ------------------------ Tipografia -------------------------- */
-h1, h2, h3, h4, h5, h6 {
-  font-family: 'Playfair Display', serif;
-  font-weight: 500;
-  line-height: 1.2;
-}
-
-/* Usa var(--vh) p/ corrigir o 100vh no iOS */
-.App {
-  width: 100%;
-  height: calc(var(--vh, 1vh) * 100);
-  display: flex; align-items: center; justify-content: center;
-}
-@supports (height: 100dvh) { .App { height: 100dvh; } }
-
-/* Inputs */
-input, textarea { font-size: 16px; }
-* { -webkit-tap-highlight-color: transparent; }
-button, [role="button"], a { touch-action: manipulation; }
-
-/* Foco visível acessível */
-:where(button,[role="button"],a,input,textarea,select):focus-visible {
-  outline: 2px solid rgba(59,130,246,.55);
-  outline-offset: 2px;
-}
-@media (prefers-color-scheme: dark) {
-  :where(button,[role="button"],a,input,textarea,select):focus-visible {
-    outline-color: rgba(147,197,253,.7);
-  }
-}
-
-/* ------------------ Base p/ bolhas de chat -------------------- */
-.chat-bubble-base{
-  display:inline-block;
-  max-width:min(720px, 88vw);
-  overflow-wrap: break-word;   /* evita quebrar “o|l|á” */
-  word-break: normal;
-  hyphens:auto;
-  line-height:1.55;
-}
-
-/* Força sans dentro da bolha */
-.message-bubble, .message-bubble * {
-  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji" !important;
-}
-
-/* Bolha de vidro decorativa */
-.eco-glass-bubble {
-  width: 256px; height: 256px; border-radius: 9999px;
-  background-color: rgba(255,255,255,0.25);
-  backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(0,0,0,0.06);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
-}
-
-/* ------------------------ Animações --------------------------- */
-@keyframes fadeIn { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
-@keyframes floating-animation { 0%{transform:translateY(0)} 50%{transform:translateY(-3px)} 100%{transform:translateY(0)} }
-@keyframes pulse-dot { 0%,100%{opacity:.2} 50%{opacity:1} }
-@keyframes gentlePulse { 0%,100%{transform:scale(1);opacity:1} 50%{transform:scale(1.03);opacity:.95} }
-@keyframes typingWave { 0%{transform:translateY(0);opacity:.4} 25%{transform:translateY(-4px);opacity:1} 50%{transform:translateY(0);opacity:.4} 100%{transform:translateY(0);opacity:.4} }
-
-.animate-gentle-pulse { animation: gentlePulse 3s ease-in-out infinite; }
-.floating { animation: floating-animation 8s ease-in-out infinite; }
-.vibrating { animation: vibrating-animation .6s ease-in-out infinite; }
-
-/* ---------------- Indicador de digitação ---------------------- */
-.typing-indicator{
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  gap:4px;
-  width: fit-content;
-  min-width: 0;
-  min-height: 18px;
-}
-.typing-dots{ display:inline-flex; gap:4px; }
-.typing-dots > span{
-  width:5px; height:5px; border-radius:9999px;
-  background:#6b7280; opacity:.85;
-  animation: typingWave 1s ease-in-out infinite;
-}
-.typing-dots > span:nth-child(2){ animation-delay:.15s; }
-.typing-dots > span:nth-child(3){ animation-delay:.30s; }
-
-.bubble-typing{ padding:6px 10px !important; border-radius:14px !important; }
-
-/* ------------------ Mensagens (glass style) ------------------- */
-.message-eco,
-.message-user {
-  padding: 10px 14px;
-  border-radius: 18px;
-  font-size: 0.95rem;
-  line-height: 1.55;
-  max-width: min(720px, 88vw);
-  overflow-wrap: break-word;   /* consistente com .chat-bubble-base */
-  word-break: normal;
-  white-space: pre-wrap;       /* respeita \n do modelo */
-  transition: transform .15s ease, background-color .2s ease, border-color .2s ease, box-shadow .2s ease;
-  position: relative;
-  -webkit-backdrop-filter: saturate(1.2) blur(14px);
-  backdrop-filter: saturate(1.2) blur(14px);
-  box-shadow: var(--bubble-shadow);
-  border: 1px solid var(--bubble-border);
-}
-.message-eco { background: var(--bubble-eco-bg); color:#0f172a; border-bottom-left-radius: 6px; }
-.message-user{ background: var(--bubble-user-bg); color:#0f172a; border-bottom-right-radius: 6px; }
-
-/* brilho interno sutil (efeito iMessage) */
-.message-eco::before, .message-user::before{
-  content:""; position:absolute; inset:0; border-radius: inherit;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.65); pointer-events:none;
-}
-
-/* Hover leve (desktop) */
-@media (hover:hover) {
-  .message-eco:hover, .message-user:hover { transform: translateY(-1px); will-change: transform; }
-}
-
-/* Fallback sem backdrop-filter */
-@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
-  .message-eco, .message-user {
-    background: rgba(255,255,255,0.92);
-    border: 1px solid rgba(0,0,0,0.06);
-    box-shadow: 0 6px 16px rgba(0,0,0,0.06);
-  }
-}
-
-/* ----------------- Barra de ações das mensagens --------------- */
-.msg-actions { display: flex; gap: 6px; align-items: center; }
-.msg-actions button { padding: 6px; border-radius: 8px; }
-.msg-actions button svg { width: 18px; height: 18px; color: #6b7280; }
-.msg-actions button:hover { background: #f3f4f6; }
-@media (max-width: 380px) { .msg-actions button svg { width: 16px; height: 16px; } }
-
-/* Ícone bolha (EcoBubbleIcon) */
-.eco-bubble-icon {
-  width: 32px; height: 32px; border-radius: 50%;
-  background: var(--eco-bubble-gradient);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
-}
-
-/* ----------------------- Scrollbar ---------------------------- */
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background-color: rgba(0,0,0,0.12); border-radius: 10px; }
-* { scrollbar-width: thin; scrollbar-color: rgba(0,0,0,.24) transparent; }
-
-/* -------------------- Textos com gradiente -------------------- */
-.text-gradient-blue,
-.text-gradient-rose {
-  display: inline-block;
-  -webkit-background-clip: text; background-clip: text;
-  color: transparent; -webkit-text-fill-color: transparent;
-}
-/* Agora o gradiente é branco -> branco translúcido */
-.text-gradient-blue { background-image: linear-gradient(90deg, var(--cerulean-blue), rgba(255,255,255,0.92)); }
-.text-gradient-rose { background-image: linear-gradient(90deg, var(--rose-quartz),   rgba(255,255,255,0.92)); }
-
-/* ---- Alturas e teclado (iOS/Android) ---- */
-body.keyboard-open { overscroll-behavior-y: contain; padding-bottom: var(--safe-bottom); }
-
-/* ---------- Redução de movimento ---------- */
-@media (prefers-reduced-motion: reduce) {
-  html * { transition: none !important; }
-  .reduce-motion * { animation: none !important; }
-}
-
-/* ----------------- RESPONSIVIDADE DA SIDEBAR ----------------- */
-@media (max-width: 767px) { :root { --eco-sidebar-w: 0px !important; } }
-
-/* Foco genérico (fallback) */
-:focus-visible { outline: 2px solid rgba(148,163,184,.45); outline-offset: 2px; }
-
-/* Seleção de texto */
-::selection { background: rgba(148,163,184,.25); }
-
-/* ---- ECO minimal v2 ---- */
-.glass-card {
-  background: rgba(255,255,255,.86);
-  -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px);
-  border: 1px solid rgba(2,6,23,.06);
+/* Legacy helpers kept for other screens while adopting the new palette */
+.glass,
+.glass-soft,
+.glass-panel,
+.glass-card,
+.input-glass {
+  background: var(--surface);
+  backdrop-filter: saturate(1.05) blur(18px);
+  -webkit-backdrop-filter: saturate(1.05) blur(18px);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-xs);
   border-radius: 24px;
-  box-shadow:
-    0 1px 0 rgba(255,255,255,.8) inset,
-    0 20px 60px rgba(2,6,23,.08),
-    0 8px 24px rgba(2,6,23,.06);
-  contain: paint;
 }
-.eco-wordmark { letter-spacing:.08em; }
+
+.glass-soft {
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+}
+
+.glass-panel {
+  border-radius: 20px;
+  box-shadow: var(--shadow-xs), var(--shadow-lg);
+}
+
+.glass-card {
+  border-radius: 28px;
+  box-shadow: var(--shadow-xs), var(--shadow-lg);
+}
 
 .input-glass {
-  height: 48px; width: 100%;
-  border-radius: 14px; padding: 0 14px;
-  background: rgba(255,255,255,.9);
-  border: 1px solid rgba(2,6,23,.08);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.7);
-}
-.input-glass:focus {
-  outline: none; border-color: rgba(2,6,23,.08);
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,.7),
-    0 0 0 3px rgba(148,163,184,.22);
+  width: 100%;
+  border-radius: 18px;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  color: var(--ink);
 }
 
-.btn-apple {
-  position: relative; isolation:isolate;
-  height: 48px; border-radius: 14px;
-  display:flex; align-items:center; justify-content:center;
-  padding: 0 16px; font-weight:600;
-  background: #ffffff; color:#0f172a;
-  border: 1px solid rgba(2,6,23,.08);
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,.85),
-    0 8px 24px rgba(2,6,23,.06);
-  transition: transform .06s ease, filter .2s ease, background .2s ease;
-}
-.btn-apple:hover { filter: brightness(1.02); }
-.btn-apple:active { transform: translateY(1px); }
-.btn-apple[disabled]{ opacity:.6; cursor:not-allowed; transform:none; }
-
-.btn-apple-primary { background: linear-gradient(180deg, #f3f6f8 0%, #e8eef2 100%); color:#0f172a; border: 1px solid rgba(2,6,23,.08); }
-
-.divider-soft { display:flex; align-items:center; gap:12px; padding-top:2px; }
-.divider-soft > span { flex:1; height:1px; background: rgba(2,6,23,.08); }
-
-/* Pills “ambient” */
-.pill-ambient {
-  display:inline-flex; align-items:center; gap:10px;
-  padding: 8px 14px; border-radius: 9999px;
-  background:#ffffff; border: 1px solid rgba(2,6,23,.08);
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,.85),
-    0 10px 30px rgba(2,6,23,.06);
-}
-.pill-ambient .mini-dot { width:8px; height:8px; border-radius:9999px; background:#0284c7; }
-.pill-ambient .mini-bubble {
-  width:24px; height:24px; border-radius:9999px;
-  background: radial-gradient(38% 32% at 38% 32%, #fff 0%, #dfeffc 45%, #c6bfff 100%);
-  border:1px solid rgba(255,255,255,.9);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.9), 0 1px 2px rgba(2,6,23,.16);
+.glass-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  padding: 0.6rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.65));
+  color: var(--ink);
+  box-shadow: var(--shadow-xs);
 }
 
-/* Espaçamentos verticais */
-.stack-quiet > * + * { margin-top: .75rem; }
-.stack-roomy > * + * { margin-top: 1rem; }
-
-/* Otimização mobile: reduzir blur alto */
-@media (max-width: 480px) {
-  .glass { backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); }
-  .glass-strong { backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); }
-  .message-eco, .message-user {
-    -webkit-backdrop-filter: saturate(1.1) blur(12px);
-    backdrop-filter: saturate(1.1) blur(12px);
-  }
+.glass-popover {
+  background: color-mix(in srgb, var(--surface) 82%, transparent);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border: 1px solid var(--surface-border);
+  border-radius: 16px;
+  box-shadow: var(--shadow-xs), var(--shadow-lg);
 }
 
-/* Em telas com pointer “coarse” (toque), suavize blur */
-@media (pointer: coarse) and (hover: none) {
-  .glass, .glass-strong, .message-eco, .message-user {
-    -webkit-backdrop-filter: blur(10px);
-    backdrop-filter: blur(10px);
-  }
-}
-
-/* Acessibilidade extra */
-.visually-hidden {
-  position: absolute !important;
-  width: 1px; height: 1px;
-  padding: 0; margin: -1px; overflow: hidden;
-  clip: rect(0 0 0 0); white-space: nowrap; border: 0;
-}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,25 +1,37 @@
 /* -------------------------------------------------------------------------- */
-/*  ChatPage.tsx — scroll estável + sem bolinha fantasma + saudação alinhada  */
+/*  ChatPage.tsx — Apple-inspired glass UI with virtualization and retries    */
 /* -------------------------------------------------------------------------- */
 
-import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
+import React, {
+  Dispatch,
+  lazy,
+  memo,
+  Suspense,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  SetStateAction,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { motion } from 'framer-motion';
 
 import ChatMessage from '../components/ChatMessage';
 import ChatInput from '../components/ChatInput';
-import EcoBubbleIcon from '../components/EcoBubbleIcon';
-import EcoMessageWithAudio from '../components/EcoMessageWithAudio';
 import QuickSuggestions, { Suggestion } from '../components/QuickSuggestions';
 import TypingDots from '../components/TypingDots';
+import EcoBubbleIcon from '../components/EcoBubbleIcon';
+import { GlassToolbar } from '../components/ui/Primitives';
 
 import { enviarMensagemParaEco } from '../api/ecoApi';
 import { buscarUltimasMemoriasComTags, buscarMemoriasSemelhantesV2 } from '../api/memoriaApi';
+import { salvarMensagem } from '../api/mensagem';
 
 import { useAuth } from '../contexts/AuthContext';
-import { useChat } from '../contexts/ChatContext';
-import { salvarMensagem } from '../api/mensagem';
+import { useChat, Message } from '../contexts/ChatContext';
 
 import { differenceInDays } from 'date-fns';
 import { extrairTagsRelevantes } from '../utils/extrairTagsRelevantes';
@@ -27,7 +39,12 @@ import mixpanel from '../lib/mixpanel';
 
 import { FeedbackPrompt } from '../components/FeedbackPrompt';
 
+const EcoMessageWithAudio = lazy(() => import('../components/EcoMessageWithAudio'));
+
 const FEEDBACK_KEY = 'eco_feedback_given';
+const ESTIMATED_ROW_HEIGHT = 132;
+const ROW_GAP = 16;
+const OVERSCAN = 8;
 
 const saudacaoDoDiaFromHour = (h: number) => {
   if (h < 6) return 'Boa noite';
@@ -36,16 +53,14 @@ const saudacaoDoDiaFromHour = (h: number) => {
   return 'Boa noite';
 };
 
-/* ====== Frases rotativas ====== */
 const ROTATING_ITEMS: Suggestion[] = [
   { id: 'rot_presenca_scan', icon: '🌬️', label: 'Vamos fazer um mini-scan de presença agora?', modules: ['eco_observador_presente', 'eco_presenca_silenciosa', 'eco_corpo_emocao'], systemHint: 'Conduza um body scan curto (2–3 minutos), com foco gentil em respiração, pontos de contato e 1 pensamento.' },
-  { id: 'rot_kahneman_check', icon: '🧩', label: 'Quero checar se caí em algum atalho mental hoje', modules: ['eco_heuristica_ancoragem','eco_heuristica_disponibilidade','eco_heuristica_excesso_confianca'], systemHint: 'Explique heurísticas em linguagem simples, faça 1 pergunta diagnóstica e proponha 1 reframe prático.' },
-  { id: 'rot_vulnerabilidade', icon: '💗', label: 'Posso explorar coragem & vulnerabilidade em 1 situação', modules: ['eco_vulnerabilidade_defesas','eco_vulnerabilidade_mitos','eco_emo_vergonha_combate'], systemHint: 'Brené Brown: diferencie vulnerabilidade de exposição. Nomeie 1 defesa ativa e proponha 1 micro-ato de coragem.' },
-  { id: 'rot_estoico', icon: '🏛️', label: 'O que está sob meu controle hoje?', modules: ['eco_presenca_racional','eco_identificacao_mente','eco_fim_do_sofrimento'], systemHint: 'Marco Aurélio: conduza 3 perguntas (controle / julgamento / ação mínima) e feche com 1 compromisso simples.' },
-  { id: 'rot_regressao_media', icon: '📉', label: 'Talvez ontem foi exceção — quero revisar expectativas', modules: ['eco_heuristica_regressao_media','eco_heuristica_certeza_emocional'], systemHint: 'Explique regressão à média e convide a recalibrar expectativas com 1 evidência observável para hoje.' },
+  { id: 'rot_kahneman_check', icon: '🧩', label: 'Quero checar se caí em algum atalho mental hoje', modules: ['eco_heuristica_ancoragem', 'eco_heuristica_disponibilidade', 'eco_heuristica_excesso_confianca'], systemHint: 'Explique heurísticas em linguagem simples, faça 1 pergunta diagnóstica e proponha 1 reframe prático.' },
+  { id: 'rot_vulnerabilidade', icon: '💗', label: 'Posso explorar coragem & vulnerabilidade em 1 situação', modules: ['eco_vulnerabilidade_defesas', 'eco_vulnerabilidade_mitos', 'eco_emo_vergonha_combate'], systemHint: 'Brené Brown: diferencie vulnerabilidade de exposição. Nomeie 1 defesa ativa e proponha 1 micro-ato de coragem.' },
+  { id: 'rot_estoico', icon: '🏛️', label: 'O que está sob meu controle hoje?', modules: ['eco_presenca_racional', 'eco_identificacao_mente', 'eco_fim_do_sofrimento'], systemHint: 'Marco Aurélio: conduza 3 perguntas (controle / julgamento / ação mínima) e feche com 1 compromisso simples.' },
+  { id: 'rot_regressao_media', icon: '📉', label: 'Talvez ontem foi exceção — quero revisar expectativas', modules: ['eco_heuristica_regressao_media', 'eco_heuristica_certeza_emocional'], systemHint: 'Explique regressão à média e convide a recalibrar expectativas com 1 evidência observável para hoje.' },
 ];
 
-/* ====== Variações de abertura ====== */
 const OPENING_VARIATIONS = [
   'Pronto para começar?',
   'O que está vivo em você agora?',
@@ -54,113 +69,138 @@ const OPENING_VARIATIONS = [
   'Um passo de cada vez: por onde vamos?',
 ];
 
+type PositionedMessage = {
+  message: Message;
+  index: number;
+  top: number;
+  height: number;
+};
+
+const findIndexForOffset = (items: PositionedMessage[], offset: number) => {
+  let low = 0;
+  let high = items.length - 1;
+  let answer = items.length;
+
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    const item = items[mid];
+    if (item.top + item.height > offset) {
+      answer = mid;
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  return answer;
+};
+
+const parseStatus = (error: any): number | undefined => {
+  if (typeof error?.status === 'number') return error.status;
+  const match = String(error?.message ?? '').match(/(\d{3})/);
+  const parsed = match ? Number(match[1]) : NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const MessageRow = memo(
+  ({
+    meta,
+    virtualization,
+    onMeasure,
+  }: {
+    meta: PositionedMessage;
+    virtualization: boolean;
+    onMeasure: (id: string, height: number) => void;
+  }) => {
+    const rowRef = useRef<HTMLDivElement | null>(null);
+
+    useLayoutEffect(() => {
+      const el = rowRef.current;
+      if (!el) return;
+      const measure = () => {
+        const rect = el.getBoundingClientRect();
+        if (rect.height) onMeasure(meta.message.id, rect.height);
+      };
+      measure();
+      const observer = new ResizeObserver(measure);
+      observer.observe(el);
+      return () => observer.disconnect();
+    }, [meta.message.id, onMeasure]);
+
+    return (
+      <div
+        ref={rowRef}
+        className="message-row"
+        data-virtual={virtualization ? 'true' : 'false'}
+        style={virtualization ? { transform: `translateY(${meta.top}px)` } : undefined}
+      >
+        <div className="flex justify-center pt-1">
+          {meta.message.sender === 'eco' ? (
+            <EcoBubbleIcon size={28} />
+          ) : (
+            <span className="message-row__spacer" aria-hidden />
+          )}
+        </div>
+        <div className="min-w-0">
+          {meta.message.sender === 'eco' ? (
+            <Suspense fallback={<ChatMessage message={meta.message} />}>
+              <EcoMessageWithAudio message={meta.message} />
+            </Suspense>
+          ) : (
+            <ChatMessage message={meta.message} />
+          )}
+        </div>
+        <span className="message-row__spacer" aria-hidden />
+      </div>
+    );
+  }
+);
+MessageRow.displayName = 'MessageRow';
+
 const ChatPage: React.FC = () => {
-  const { messages, addMessage } = useChat();
-  const { userId, userName = 'Usuário', user } = useAuth();
   const navigate = useNavigate();
+  const { messages, addMessage, updateMessage, setMessages } = useChat();
+  const { userId, userName = 'Usuário', user } = useAuth();
+
+  const setMessagesDispatch = useMemo(
+    () => setMessages as unknown as Dispatch<SetStateAction<Message[]>>,
+    [setMessages]
+  );
 
   const [digitando, setDigitando] = useState(false);
   const [erroApi, setErroApi] = useState<string | null>(null);
-
-  const scrollerRef = useRef<HTMLDivElement>(null);
-  const endRef = useRef<HTMLDivElement>(null);
-  const inputBarRef = useRef<HTMLDivElement>(null);
-
-  const [showFeedback, setShowFeedback] = useState(false);
-  const aiMessages = (messages || []).filter((m: any) => m.sender === 'eco');
-
   const [showQuick, setShowQuick] = useState(true);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [showScrollBtn, setShowScrollBtn] = useState(false);
+  const [showFeedback, setShowFeedback] = useState(false);
 
-  const nearBottom = (el: HTMLDivElement, pad = 16) =>
-    el.scrollTop + el.clientHeight >= el.scrollHeight - pad;
+  const requestAbortRef = useRef<AbortController | null>(null);
+  const streamMessageRef = useRef<string | null>(null);
+
+  const scrollerRef = useRef<HTMLDivElement>(null);
+
+  const messagesRef = useRef<Message[]>(messages);
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
 
   useEffect(() => {
     if (!user) {
       navigate('/login');
       return;
     }
-    mixpanel.track('Eco: Entrou no Chat', { userId, userName, timestamp: new Date().toISOString() });
+    mixpanel.track('Eco: Entrou no Chat', {
+      userId,
+      userName,
+      timestamp: new Date().toISOString(),
+    });
   }, [user, navigate, userId, userName]);
 
   if (!user) return null;
 
-  const clientHourNow = new Date().getHours();
-  const saudacao = saudacaoDoDiaFromHour(clientHourNow);
-
-  /* ====================== SCROLL CORE (estável) ====================== */
-
-  const scrollToBottom = (smooth = true) => {
-    const el = scrollerRef.current;
-    if (!el) return;
-    const behavior: ScrollBehavior = smooth ? 'smooth' : 'auto';
-    requestAnimationFrame(() => {
-      el.scrollTo({ top: el.scrollHeight, behavior });
-      const at = nearBottom(el, 8);
-      setIsAtBottom(at);
-      setShowScrollBtn(!at);
-    });
-  };
-
-  // início no fundo
-  useEffect(() => {
-    scrollToBottom(false);
-  }, []);
-
-  // se já estava perto do fundo, mantenha no fundo ao chegar msg nova / estado de digitação mudar
-  useLayoutEffect(() => {
-    const el = scrollerRef.current;
-    if (!el) return;
-    if (nearBottom(el, 120)) scrollToBottom(true);
-  }, [messages, digitando]);
-
-  const handleScroll = () => {
-    const el = scrollerRef.current!;
-    const at = nearBottom(el, 16);
-    setIsAtBottom(at);
-    setShowScrollBtn(!at);
-  };
-
-  // iOS keyboard / visualViewport — sem jitter (opcional manter)
-  useEffect(() => {
-    const vv = (window as any).visualViewport as VisualViewport | undefined;
-    const wasAtBottomRef = { current: true };
-
-    const handleFocusIn = () => {
-      document.body.classList.add('keyboard-open');
-      const el = scrollerRef.current;
-      wasAtBottomRef.current = !!el && nearBottom(el, 120);
-    };
-    const handleFocusOut = () => {
-      document.body.classList.remove('keyboard-open');
-    };
-    window.addEventListener('focusin', handleFocusIn);
-    window.addEventListener('focusout', handleFocusOut);
-
-    if (!vv) return () => {
-      window.removeEventListener('focusin', handleFocusIn);
-      window.removeEventListener('focusout', handleFocusOut);
-    };
-
-    let raf = 0; let scheduled = false;
-    const measure = () => { scheduled = false; if (wasAtBottomRef.current) scrollToBottom(false); };
-    const scheduleMeasure = () => { if (!scheduled) { scheduled = true; raf = requestAnimationFrame(measure); } };
-
-    vv.addEventListener('resize', scheduleMeasure);
-    vv.addEventListener('scroll', scheduleMeasure);
-    scheduleMeasure();
-
-    return () => {
-      window.removeEventListener('focusin', handleFocusIn);
-      window.removeEventListener('focusout', handleFocusOut);
-      vv.removeEventListener('resize', scheduleMeasure);
-      vv.removeEventListener('scroll', scheduleMeasure);
-      if (raf) cancelAnimationFrame(raf);
-    };
-  }, []);
-
-  /* ====================== LÓGICA DO CHAT ====================== */
+  const aiMessages = useMemo(() => messages.filter((m) => m.sender === 'eco'), [messages]);
 
   useEffect(() => {
     const already = sessionStorage.getItem(FEEDBACK_KEY);
@@ -192,234 +232,458 @@ const ChatPage: React.FC = () => {
     };
   }, []);
 
-  const gerarMensagemRetorno = (mem: any): string | null => {
+  const measurementCache = useRef<Map<string, number>>(new Map());
+  const [measureVersion, setMeasureVersion] = useState(0);
+
+  const updateMeasurement = useCallback((id: string, height: number) => {
+    const cache = measurementCache.current;
+    const rounded = Math.round(height);
+    if (rounded <= 0) return;
+    if (cache.get(id) !== rounded) {
+      cache.set(id, rounded);
+      setMeasureVersion((v) => v + 1);
+    }
+  }, []);
+
+  const virtualizationEnabled = useMemo(() => messages.length > 200, [messages.length]);
+
+  const { positionedMessages, virtualHeight } = useMemo(() => {
+    let offset = 0;
+    const metas = messages.map((message, index) => {
+      const cached = measurementCache.current.get(message.id) ?? ESTIMATED_ROW_HEIGHT;
+      const height = cached + ROW_GAP;
+      const meta: PositionedMessage = {
+        message,
+        index,
+        top: offset,
+        height,
+      };
+      offset += height;
+      return meta;
+    });
+    return { positionedMessages: metas, virtualHeight: offset };
+  }, [messages, measureVersion]);
+
+  const [visibleRange, setVisibleRange] = useState({ start: 0, end: messages.length });
+
+  const updateVirtualWindow = useCallback(() => {
+    if (!virtualizationEnabled) return;
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    const scrollTop = scroller.scrollTop;
+    const viewHeight = scroller.clientHeight;
+    const startIndex = Math.max(0, findIndexForOffset(positionedMessages, scrollTop) - OVERSCAN);
+    const endIndex = Math.min(
+      positionedMessages.length,
+      findIndexForOffset(positionedMessages, scrollTop + viewHeight) + OVERSCAN
+    );
+    setVisibleRange({ start: startIndex, end: endIndex });
+  }, [positionedMessages, virtualizationEnabled]);
+
+  useEffect(() => {
+    if (!virtualizationEnabled) {
+      setVisibleRange({ start: 0, end: positionedMessages.length });
+      return;
+    }
+    setVisibleRange({
+      start: Math.max(0, positionedMessages.length - 60),
+      end: positionedMessages.length,
+    });
+  }, [positionedMessages.length, virtualizationEnabled]);
+
+  useEffect(() => {
+    if (virtualizationEnabled) updateVirtualWindow();
+  }, [virtualizationEnabled, updateVirtualWindow, positionedMessages]);
+
+  const visibleItems = useMemo(() => {
+    if (!virtualizationEnabled) return positionedMessages;
+    return positionedMessages.slice(visibleRange.start, visibleRange.end);
+  }, [positionedMessages, visibleRange, virtualizationEnabled]);
+
+  const nearBottom = useCallback((el: HTMLDivElement, pad = 16) => {
+    return el.scrollTop + el.clientHeight >= el.scrollHeight - pad;
+  }, []);
+
+  const scrollToBottom = useCallback(
+    (smooth = true) => {
+      const el = scrollerRef.current;
+      if (!el) return;
+      const behavior: ScrollBehavior = smooth ? 'smooth' : 'auto';
+      const target = virtualizationEnabled ? Math.max(virtualHeight - el.clientHeight, 0) : el.scrollHeight;
+      requestAnimationFrame(() => {
+        el.scrollTo({ top: target, behavior });
+        const at = nearBottom(el, 24);
+        setIsAtBottom(at);
+        setShowScrollBtn(!at);
+        if (virtualizationEnabled) updateVirtualWindow();
+      });
+    },
+    [nearBottom, virtualizationEnabled, virtualHeight, updateVirtualWindow]
+  );
+
+  useEffect(() => {
+    scrollToBottom(false);
+  }, []); // mount
+
+  useLayoutEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    if (nearBottom(el, 120)) scrollToBottom(true);
+  }, [messages.length, digitando, nearBottom, scrollToBottom]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const at = nearBottom(el, 18);
+    setIsAtBottom(at);
+    setShowScrollBtn(!at);
+    if (virtualizationEnabled) updateVirtualWindow();
+  }, [nearBottom, updateVirtualWindow, virtualizationEnabled]);
+
+  useEffect(() => {
+    const vv = (window as any).visualViewport as VisualViewport | undefined;
+    if (!vv) return;
+    let raf = 0;
+    const handle = () => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        if (isAtBottom) scrollToBottom(false);
+      });
+    };
+    vv.addEventListener('resize', handle);
+    vv.addEventListener('scroll', handle);
+    return () => {
+      vv.removeEventListener('resize', handle);
+      vv.removeEventListener('scroll', handle);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [isAtBottom, scrollToBottom]);
+
+  const clearPendingAssistant = useCallback(() => {
+    const pendingId = streamMessageRef.current;
+    if (!pendingId) return;
+    streamMessageRef.current = null;
+    setMessagesDispatch((prev) => prev.filter((msg) => msg.id !== pendingId));
+  }, [setMessagesDispatch]);
+
+  const commitAssistantMessage = useCallback(
+    (text: string) => {
+      const pendingId = streamMessageRef.current;
+      if (pendingId) {
+        updateMessage(pendingId, text);
+        streamMessageRef.current = null;
+      } else if (text) {
+        addMessage({ id: uuidv4(), text, sender: 'eco' });
+      }
+    },
+    [addMessage, updateMessage]
+  );
+
+  const gerarMensagemRetorno = useCallback((mem: any): string | null => {
     if (!mem) return null;
     const dias = differenceInDays(new Date(), new Date(mem.created_at));
     if (dias === 0) return null;
     const resumo = mem.resumo_eco || 'algo que foi sentido';
     return `O usuário retorna após ${dias} dias. Na última interação significativa, compartilhou: “${resumo}”. Use isso para acolher o reencontro com sensibilidade.`;
-  };
+  }, []);
 
-  const handleSendMessage = async (text: string, systemHint?: string) => {
-    const raw = text ?? '';
-    const trimmed = raw.trim();
-    if (!trimmed || digitando) return;
+  const handleSendMessage = useCallback(
+    async (text: string, systemHint?: string) => {
+      const trimmed = (text ?? '').trim();
+      if (!trimmed || digitando) return;
 
-    setDigitando(true);
-    setErroApi(null);
+      setDigitando(true);
+      setErroApi(null);
+      setShowQuick(false);
 
-    const userLocalId = uuidv4();
-    addMessage({ id: userLocalId, text: trimmed, sender: 'user' });
+      const userLocalId = uuidv4();
+      addMessage({ id: userLocalId, text: trimmed, sender: 'user' });
+      requestAnimationFrame(() => scrollToBottom(true));
 
-    requestAnimationFrame(() => scrollToBottom(true));
-
-    mixpanel.track('Eco: Mensagem Enviada', { userId, userName, mensagem: trimmed, timestamp: new Date().toISOString() });
-
-    try {
-      const saved = await salvarMensagem({ usuarioId: userId!, conteudo: trimmed, sentimento: '', salvarMemoria: true });
-      const mensagemId = saved?.[0]?.id || userLocalId;
-
-      const baseHistory = [...messages, { id: mensagemId, role: 'user', content: trimmed }];
-
-      const tags = extrairTagsRelevantes(trimmed);
-      const [similar, porTag] = await Promise.all([
-        // ⇩ usa v2 com k/threshold/usuario_id
-        buscarMemoriasSemelhantesV2(trimmed, { k: 3, threshold: 0.12, usuario_id: userId! }).catch(() => []),
-        tags.length ? buscarUltimasMemoriasComTags(userId!, tags, 2).catch(() => []) : Promise.resolve([]),
-      ]);
-
-      // mescla e deduplica (por id ou hash simples de data+resumo)
-      const vistos = new Set<string>();
-      const mems = [...(similar || []), ...(porTag || [])].filter((m: any) => {
-        const key = m.id || `${m.created_at}-${m.resumo_eco}`;
-        if (vistos.has(key)) return false;
-        vistos.add(key);
-        return true;
-      });
-
-      const ctxMems = (mems || [])
-        .map((m: any) => {
-          const data = new Date(m.created_at || '').toLocaleDateString();
-          const tgs = m.tags?.length ? ` [tags: ${m.tags.join(', ')}]` : '';
-          // inclui similaridade quando disponível (0–1 → %)
-          const sim = typeof m.similarity === 'number' ? ` ~${Math.round(m.similarity * 100)}%` : '';
-          return `(${data}) ${m.resumo_eco}${tgs}${sim}`;
-        })
-        .join('\n');
-
-      const memSignif = (mems || []).find((m: any) => (m.intensidade ?? 0) >= 7);
-      const retorno = gerarMensagemRetorno(memSignif);
-
-      const preSistema: any[] = [];
-      if (systemHint) preSistema.push({ role: 'system', content: systemHint });
-      if (retorno) preSistema.push({ role: 'system', content: retorno });
-      if (ctxMems) preSistema.push({ role: 'system', content: `Memórias recentes relevantes:\n${ctxMems}` });
-
-      // reduz histórico enviado (mantém comportamento estável)
-      const janelaHistorico = baseHistory.slice(-3);
-
-      const mensagensComContexto = [
-        ...preSistema,
-        ...janelaHistorico.map((m: any) => ({
-          role: (m.role as any) || (m.sender === 'eco' ? 'assistant' : 'user'),
-          content: m.content || m.text || '',
-        })),
-      ];
-
-      const clientHour = new Date().getHours();
-      const clientTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-      const resposta = await enviarMensagemParaEco(mensagensComContexto, userName, userId!, clientHour, clientTz);
-
-      const textoEco = (resposta || '').replace(/\n\{[\s\S]*\}\s*$/m, '').trim();
-      if (textoEco) addMessage({ id: uuidv4(), text: textoEco, sender: 'eco' });
-
-      const match = (resposta || '').match(/\{[\s\S]*\}$/);
-      if (match) {
-        try {
-          const bloco = JSON.parse(match[0]);
-          if (typeof bloco?.intensidade === 'number' && bloco.intensidade >= 7) {
-            mixpanel.track('Memória Registrada', {
-              intensidade: bloco.intensidade,
-              emocao_principal: bloco.emocao_principal || 'desconhecida',
-              modulo_ativado: bloco.modulo_ativado || 'não informado',
-              dominio_vida: bloco.dominio_vida || 'geral',
-              padrao_comportamental: bloco.padrao_comportamental || 'não identificado',
-            });
-          }
-        } catch {}
-      }
-    } catch (err: any) {
-      console.error('[ChatPage] erro:', err);
-      setErroApi(err?.message || 'Falha ao enviar mensagem.');
-      mixpanel.track('Eco: Erro ao Enviar Mensagem', {
+      mixpanel.track('Eco: Mensagem Enviada', {
         userId,
-        erro: err?.message || 'desconhecido',
-        mensagem: (text || '').slice(0, 120),
+        userName,
+        mensagem: trimmed,
         timestamp: new Date().toISOString(),
       });
-    } finally {
-      setDigitando(false);
-      scrollToBottom(true);
-    }
-  };
 
-  const handlePickSuggestion = async (s: Suggestion) => {
-    setShowQuick(false);
-    mixpanel.track('Eco: QuickSuggestion Click', { id: s.id, label: s.label, modules: s.modules });
-    const hint =
-      (s.modules?.length || s.systemHint)
-        ? `${s.modules?.length ? `Ative módulos: ${s.modules.join(', ')}.` : ''}${s.systemHint ? ` ${s.systemHint}` : ''}`.trim()
-        : '';
-    const userText = `${s.icon ? s.icon + ' ' : ''}${s.label}`;
-    await handleSendMessage(userText, hint);
-  };
+      const controller = new AbortController();
+      requestAbortRef.current?.abort();
+      requestAbortRef.current = controller;
+
+      try {
+        const saved = await salvarMensagem({
+          usuarioId: userId!,
+          conteudo: trimmed,
+          sentimento: '',
+          salvarMemoria: true,
+        });
+        const mensagemId = saved?.[0]?.id || userLocalId;
+
+        const baseHistory = [...messagesRef.current, { id: mensagemId, role: 'user', content: trimmed }];
+        const tags = extrairTagsRelevantes(trimmed);
+
+        const [similar, porTag] = await Promise.all([
+          buscarMemoriasSemelhantesV2(trimmed, { k: 3, threshold: 0.12, usuario_id: userId! }).catch(() => []),
+          tags.length ? buscarUltimasMemoriasComTags(userId!, tags, 2).catch(() => []) : Promise.resolve([]),
+        ]);
+
+        const vistos = new Set<string>();
+        const mems = [...(similar || []), ...(porTag || [])].filter((m: any) => {
+          const key = m.id || `${m.created_at}-${m.resumo_eco}`;
+          if (vistos.has(key)) return false;
+          vistos.add(key);
+          return true;
+        });
+
+        const ctxMems = (mems || [])
+          .map((m: any) => {
+            const data = new Date(m.created_at || '').toLocaleDateString();
+            const tgs = m.tags?.length ? ` [tags: ${m.tags.join(', ')}]` : '';
+            const sim = typeof m.similarity === 'number' ? ` ~${Math.round(m.similarity * 100)}%` : '';
+            return `(${data}) ${m.resumo_eco}${tgs}${sim}`;
+          })
+          .join('\n');
+
+        const memSignif = (mems || []).find((m: any) => (m.intensidade ?? 0) >= 7);
+        const retorno = gerarMensagemRetorno(memSignif);
+
+        const preSistema: any[] = [];
+        if (systemHint) preSistema.push({ role: 'system', content: systemHint });
+        if (retorno) preSistema.push({ role: 'system', content: retorno });
+        if (ctxMems) preSistema.push({ role: 'system', content: `Memórias recentes relevantes:\n${ctxMems}` });
+
+        const janelaHistorico = baseHistory.slice(-3);
+        const mensagensComContexto = [
+          ...preSistema,
+          ...janelaHistorico.map((m: any) => ({
+            role: (m.role as any) || (m.sender === 'eco' ? 'assistant' : 'user'),
+            content: m.content || m.text || '',
+          })),
+        ];
+
+        const clientHour = new Date().getHours();
+        const clientTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+        const maxAttempts = 3;
+        let attempt = 0;
+        let resposta = '';
+        let lastError: any = null;
+
+        while (attempt < maxAttempts) {
+          try {
+            resposta = await enviarMensagemParaEco(
+              mensagensComContexto,
+              userName,
+              userId!,
+              clientHour,
+              clientTz,
+              { signal: controller.signal }
+            );
+            lastError = null;
+            break;
+          } catch (err: any) {
+            if (controller.signal.aborted) throw err;
+            lastError = err;
+            const status = parseStatus(err);
+            if (status === 429 || (status && status >= 500 && status < 600)) {
+              const backoff = Math.min(1500 * 2 ** attempt, 6000);
+              await delay(backoff);
+              attempt += 1;
+              continue;
+            }
+            throw err;
+          }
+        }
+
+        if (lastError) throw lastError;
+
+        const textoEco = (resposta || '').replace(/\n\{[\s\S]*\}\s*$/m, '').trim();
+        if (textoEco) commitAssistantMessage(textoEco);
+
+        const match = (resposta || '').match(/\{[\s\S]*\}$/);
+        if (match) {
+          try {
+            const bloco = JSON.parse(match[0]);
+            if (typeof bloco?.intensidade === 'number' && bloco.intensidade >= 7) {
+              mixpanel.track('Memória Registrada', {
+                intensidade: bloco.intensidade,
+                emocao_principal: bloco.emocao_principal || 'desconhecida',
+                modulo_ativado: bloco.modulo_ativado || 'não informado',
+                dominio_vida: bloco.dominio_vida || 'geral',
+                padrao_comportamental: bloco.padrao_comportamental || 'não identificado',
+              });
+            }
+          } catch {}
+        }
+      } catch (err: any) {
+        if (controller.signal.aborted) return;
+        console.error('[ChatPage] erro:', err);
+        const msg = err?.message || 'Falha ao enviar mensagem.';
+        setErroApi(msg);
+        mixpanel.track('Eco: Erro ao Enviar Mensagem', {
+          userId,
+          erro: msg,
+          mensagem: (text || '').slice(0, 120),
+          timestamp: new Date().toISOString(),
+        });
+        clearPendingAssistant();
+      } finally {
+        requestAbortRef.current = null;
+        setDigitando(false);
+        scrollToBottom(true);
+      }
+    },
+    [
+      addMessage,
+      clearPendingAssistant,
+      commitAssistantMessage,
+      digitando,
+      gerarMensagemRetorno,
+      scrollToBottom,
+      setShowQuick,
+      updateMessage,
+      userId,
+      userName,
+    ]
+  );
+
+  const handlePickSuggestion = useCallback(
+    async (s: Suggestion) => {
+      setShowQuick(false);
+      mixpanel.track('Eco: QuickSuggestion Click', { id: s.id, label: s.label, modules: s.modules });
+      const hint =
+        (s.modules?.length || s.systemHint)
+          ? `${s.modules?.length ? `Ative módulos: ${s.modules.join(', ')}.` : ''}${s.systemHint ? ` ${s.systemHint}` : ''}`.trim()
+          : '';
+      const userText = `${s.icon ? s.icon + ' ' : ''}${s.label}`;
+      await handleSendMessage(userText, hint);
+    },
+    [handleSendMessage]
+  );
+
+  const saudacao = saudacaoDoDiaFromHour(new Date().getHours());
+  const openingPrompt = useMemo(
+    () => OPENING_VARIATIONS[Math.floor(Math.random() * OPENING_VARIATIONS.length)],
+    []
+  );
+
+  const streamingMessageId = streamMessageRef.current;
+  const lastAssistantId = aiMessages.at(-1)?.id;
+
+  const showInlineTyping = Boolean(digitando && streamingMessageId);
 
   return (
-    <div className="w-full h-[calc(100dvh-var(--eco-topbar-h,56px))] flex flex-col overflow-hidden bg-eco-vibe">
-      {/* SCROLLER */}
+    <div className="chat-page">
+      <GlassToolbar className="mx-auto w-full max-w-chat-container rounded-[28px]">
+        <div className="flex items-center gap-3">
+          <EcoBubbleIcon size={28} />
+          <div className="flex flex-col leading-tight">
+            <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted">ECO</span>
+            <span className="text-sm font-semibold text-[color:var(--ink)]">{saudacao}, {userName}</span>
+          </div>
+        </div>
+        <div className="hidden sm:block text-sm text-muted">{openingPrompt}</div>
+      </GlassToolbar>
+
       <div
         ref={scrollerRef}
         onScroll={handleScroll}
         role="feed"
         aria-busy={digitando}
-        className="chat-scroller flex-1 min-h-0 overflow-y-auto px-3 sm:px-6 [scrollbar-gutter:stable]"
-        style={{
-          paddingTop: 'calc(var(--eco-topbar-h,56px) + 12px)',
-          WebkitOverflowScrolling: 'touch',
-          overscrollBehaviorY: 'contain',
-          scrollPaddingTop: 'calc(var(--eco-topbar-h,56px) + 12px)',
-          touchAction: 'pan-y',
-        }}
+        className="chat-scroller"
       >
-        <div className="w-full mx-auto max-w-[720px]">
+        <div
+          className="message-list"
+          style={virtualizationEnabled ? { height: virtualHeight } : undefined}
+        >
           {messages.length === 0 && !erroApi && (
-            <div className="min-h-[calc(100svh-var(--eco-topbar-h,56px)-120px)] flex items-center justify-center">
-              <motion.div className="px-4 w-full" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.28 }}>
-                {/* Saudação no mesmo grid das mensagens */}
-                <div className="grid grid-cols-[28px,1fr,28px] items-center">
-                  <div className="hidden sm:block" />
-                  <div className="col-start-2 justify-self-start text-center sm:text-left md:max-w-[680px]">
-                    <h2 className="text-4xl md:text-5xl font-light text-gray-800 leading-tight">
-                      {saudacao}, {userName}
-                    </h2>
-                    <p className="text-base md:text-lg font-light text-slate-500 mt-3">
-                      {OPENING_VARIATIONS[Math.floor(Math.random() * OPENING_VARIATIONS.length)]}
-                    </p>
-                  </div>
-                  <div />
-                </div>
-              </motion.div>
+            <motion.div
+              className="mx-auto flex min-h-[320px] w-full max-w-chat-container flex-col items-center justify-center gap-6 text-center"
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.32, ease: 'easeOut' }}
+            >
+              <h2 className="max-w-[30ch] text-3xl font-semibold tracking-tight text-[color:var(--ink)] sm:text-4xl">
+                {saudacao}, {userName}
+              </h2>
+              <p className="max-w-[38ch] text-base text-muted sm:text-lg">{openingPrompt}</p>
+            </motion.div>
+          )}
+
+          {visibleItems.map((meta) => (
+            <MessageRow
+              key={meta.message.id}
+              meta={meta}
+              virtualization={virtualizationEnabled}
+              onMeasure={updateMeasurement}
+            />
+          ))}
+
+          {digitando && !showInlineTyping && (
+            <div className="message-row" data-virtual="false">
+              <div className="flex justify-center pt-1">
+                <EcoBubbleIcon size={28} />
+              </div>
+              <div className="min-w-0">
+                <TypingDots />
+              </div>
+              <span className="message-row__spacer" aria-hidden />
             </div>
           )}
 
           {erroApi && (
-            <div className="glass rounded-xl text-red-600 text-center mb-4 px-4 py-2">{erroApi}</div>
+            <div className="mt-6 flex justify-center">
+              <div className="surface-card max-w-sm rounded-3xl px-4 py-3 text-center text-sm font-medium text-rose-500">
+                {erroApi}
+              </div>
+            </div>
           )}
 
-          <div className="w-full space-y-3 md:space-y-4">
-            {messages.map((m) => (
-              <div key={m.id} className="grid grid-cols-[28px,1fr,28px] gap-2 items-start min-w-0">
-                {/* ESQ: avatar só quando ECO */}
-                <div className="pt-1.5">
-                  {m.sender === 'eco' ? <EcoBubbleIcon /> : <div className="w-[28px] h-[28px]" />}
-                </div>
-
-                <div className={(m.sender === 'user' ? 'justify-self-end' : 'justify-self-start') + ' min-w-0 max-w-full'}>
-                  {m.sender === 'eco' ? <EcoMessageWithAudio message={m as any} /> : <ChatMessage message={m} />}
-                </div>
-
-                {/* DIR: placeholder (evita “bolinha” fantasma) */}
-                <div className="pt-1.5">
-                  <div className="w-[28px] h-[28px]" />
-                </div>
-              </div>
-            ))}
-
-            {digitando && (
-              <div className="grid grid-cols-[28px,1fr,28px] gap-2 items-start min-w-0">
-                <div className="pt-1.5"><EcoBubbleIcon /></div>
-                <div className="justify-self-start min-w-0 max-w-full"><TypingDots /></div>
-                <div className="pt-1.5"><div className="w-[28px] h-[28px]" /></div>
-              </div>
-            )}
-
-            {/* Âncora explícita para reancoragem do scroll */}
-            <div ref={endRef} className="anchor-end h-px" />
-          </div>
+          {showFeedback && lastAssistantId && (
+            <div className="mt-6 flex justify-center">
+              <FeedbackPrompt
+                sessaoId={userId || 'anon'}
+                usuarioId={userId || undefined}
+                mensagemId={lastAssistantId}
+                onSubmitted={() => {
+                  setShowFeedback(false);
+                  sessionStorage.setItem(FEEDBACK_KEY, '1');
+                }}
+              />
+            </div>
+          )}
         </div>
 
         {showScrollBtn && (
-          <div className="sticky bottom-24 z-30 flex justify-end pr-2 sm:pr-6">
+          <div className="scroll-to-bottom">
             <button
               onClick={() => scrollToBottom(true)}
-              className="h-9 w-9 rounded-full glass-soft hover:bg-white/24 flex items-center justify-center transition"
+              className="h-10 w-10 rounded-full border border-[rgba(255,255,255,0.6)] bg-[color-mix(in_srgb,var(--surface)_90%,transparent)] text-[color:var(--ink)] shadow-[var(--shadow-xs)] transition-transform duration-200 ease-out hover:-translate-y-0.5"
               aria-label="Descer para a última mensagem"
             >
-              <svg viewBox="0 0 24 24" className="h-5 w-5 text-gray-700">
+              <svg viewBox="0 0 24 24" className="h-5 w-5">
                 <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
             </button>
           </div>
         )}
-      </div> {/* <- fecha o scroller */}
+      </div>
 
-      {/* BARRA DE INPUT */}
-      <div
-        ref={inputBarRef}
-        className="sticky bottom-0 z-40 px-3 sm:px-6 pb-2 pt-2 glass border-t-0"
-      >
-        <div className="w-full mx-auto max-w-[720px]">
+      <div className="composer-shell">
+        <div className="composer-content space-y-4">
           <QuickSuggestions
             visible={showQuick && messages.length === 0 && !digitando && !erroApi}
             onPickSuggestion={handlePickSuggestion}
             rotatingItems={ROTATING_ITEMS}
             rotationMs={5000}
-            className="mt-1 overflow-x-auto no-scrollbar [mask-image:linear-gradient(to_right,transparent,black_12%,black_88%,transparent)]"
+            className="quick-row overflow-x-auto no-scrollbar [mask-image:linear-gradient(to_right,transparent,black_12%,black_88%,transparent)]"
           />
           <ChatInput
             onSendMessage={(t) => handleSendMessage(t)}
-            onMoreOptionSelected={(opt) => { if (opt === 'go_to_voice_page') navigate('/voice'); }}
+            onMoreOptionSelected={(opt) => {
+              if (opt === 'go_to_voice_page') navigate('/voice');
+            }}
             onSendAudio={() => console.log('Áudio enviado')}
             disabled={digitando}
             onTextChange={(t) => setShowQuick(t.trim().length === 0)}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,22 +3,23 @@ import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate, useMatch } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Eye, EyeOff } from 'lucide-react';
+
 import PhoneFrame from '../components/PhoneFrame';
 import { useAuth } from '../contexts/AuthContext';
 import TourInicial from '../components/TourInicial';
 import EcoBubbleIcon from '../components/EcoBubbleIcon';
+import { Chip, GlassButton, InputField, SurfaceCard } from '../components/ui/Primitives';
 
-/* Divisor com traço mais marcado */
 const Divider: React.FC<{ label?: string }> = ({ label = 'ou' }) => (
-  <div className="relative my-4 select-none" aria-hidden="true">
-    <div className="h-px w-full bg-slate-300/70" />
-    <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-[10px] tracking-[0.14em] text-slate-500">
+  <div className="relative my-5 flex items-center justify-center text-[11px] font-medium uppercase tracking-[0.18em] text-muted">
+    <span className="h-px flex-1 bg-[rgba(15,23,42,0.08)]" aria-hidden />
+    <span className="px-3" aria-hidden>
       {label}
     </span>
+    <span className="h-px flex-1 bg-[rgba(15,23,42,0.08)]" aria-hidden />
   </div>
 );
 
-/* ---- Tradução das mensagens de erro para PT-BR (cobre Supabase/Firebase) ---- */
 function translateAuthError(err: any): string {
   const raw = [
     err?.code,
@@ -118,163 +119,129 @@ const LoginPage: React.FC = () => {
 
   return (
     <PhoneFrame>
-      {/* fundo leve para evidenciar o glass */}
-      <div className="flex h-full items-center justify-center px-6 py-10 bg-gradient-to-br from-slate-50 via-white to-slate-100">
+      <div className="relative flex h-full flex-col justify-center bg-[radial-gradient(120%_120%_at_10%_0%,rgba(226,232,240,0.32),transparent_60%),radial-gradient(140%_140%_at_90%_-10%,rgba(148,163,184,0.25),transparent_70%),var(--bg)] px-6 py-12 sm:px-8">
         {isTourActive && <TourInicial onClose={closeTour} onFinish={closeTour} />}
 
-        <motion.div
-          initial={{ y: 6, opacity: 0 }}
+        <motion.section
+          initial={{ y: 8, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          transition={{ duration: 0.28, ease: 'easeOut' }}
-          className={[
-            // GLASSMORPHISM CARD 💎 (mais marcado)
-            'w-full max-w-sm rounded-[28px] p-8 md:p-10',
-            'bg-white/35 backdrop-blur-2xl',
-            'border border-white/70 ring-1 ring-slate-900/10',
-            'shadow-[0_24px_80px_rgba(2,6,23,0.18)]',
-          ].join(' ')}
+          transition={{ duration: 0.32, ease: 'easeOut' }}
+          className="mx-auto w-full max-w-md"
         >
-          {/* Header */}
-          <div className="text-center space-y-3">
-            <h1 className="text-4xl md:text-[38px] leading-none font-semibold tracking-[-0.03em] text-slate-900 drop-shadow-[0_1px_0_rgba(255,255,255,0.65)]">
-              ECO
-            </h1>
+          <SurfaceCard className="noise-overlay gap-8 p-8 md:p-10">
+            <header className="flex flex-col items-center gap-4 text-center">
+              <Chip className="tracking-[0.18em] text-[11px] uppercase text-muted">
+                <EcoBubbleIcon size={16} className="shrink-0" />
+                Autoconhecimento guiado
+              </Chip>
+              <div className="space-y-2">
+                <h1 className="text-3xl font-semibold tracking-[-0.02em] text-[color:var(--ink)] sm:text-[2.4rem]">
+                  Bem-vindo de volta
+                </h1>
+                <p className="text-sm text-muted sm:text-base">
+                  Entre com sua conta ECO para continuar a conversa.
+                </p>
+              </div>
+            </header>
 
-            <div className="w-full flex justify-center">
-              {/* Pílula mais “Apple” e com traço forte */}
-              <span className="inline-flex items-center gap-2 rounded-full pl-2.5 pr-3 py-1.5 bg-white/75 backdrop-blur-xl border border-white/80 ring-1 ring-slate-900/5 shadow-[0_8px_24px_rgba(2,6,23,0.12)]">
-                <EcoBubbleIcon size={14} className="shrink-0" />
-                <span className="text-[14px] md:text-[15px] leading-none font-semibold text-slate-800">
-                  Autoconhecimento guiado
-                </span>
-              </span>
-            </div>
-          </div>
-
-          {/* Form */}
-          <form onSubmit={handleSubmit} className="mt-7 space-y-4" noValidate>
-            <label className="sr-only" htmlFor="email">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              placeholder="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              autoComplete="email"
-              autoCapitalize="none"
-              autoCorrect="off"
-              inputMode="email"
-              className={[
-                'w-full h-12 rounded-2xl px-4',
-                'bg-white/70 backdrop-blur-xl',
-                'border border-white/80 ring-1 ring-slate-900/5',
-                'text-slate-900 placeholder:text-slate-400',
-                'shadow-[inset_0_1px_0_rgba(255,255,255,0.7)]',
-                'focus:outline-none focus:ring-2 focus:ring-slate-700/10',
-              ].join(' ')}
-            />
-
-            <label className="sr-only" htmlFor="password">
-              Senha
-            </label>
-            <div className="relative">
-              <input
-                id="password"
-                type={showPassword ? 'text' : 'password'}
-                placeholder="Senha"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                autoComplete="current-password"
-                className={[
-                  'w-full h-12 rounded-2xl px-4 pr-11',
-                  'bg-white/70 backdrop-blur-xl',
-                  'border border-white/80 ring-1 ring-slate-900/5',
-                  'text-slate-900 placeholder:text-slate-400',
-                  'shadow-[inset_0_1px_0_rgba(255,255,255,0.7)]',
-                  'focus:outline-none focus:ring-2 focus:ring-slate-700/10',
-                ].join(' ')}
-              />
-              <button
-                type="button"
-                onClick={() => setShowPassword((v) => !v)}
-                className="absolute inset-y-0 right-1.5 my-1.5 px-2 flex items-center rounded-xl text-slate-700 hover:text-slate-900 hover:bg-white/70 focus:outline-none focus:ring-2 focus:ring-slate-700/10"
-                aria-label={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
-                title={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
-              >
-                {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-              </button>
-            </div>
-
-            {/* Mensagem de erro acessível */}
-            <div role="status" aria-live="polite" className="min-h-[1rem]">
-              {error && (
-                <motion.p
-                  className="text-rose-600 text-sm text-center"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
+            <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+              <div className="space-y-2">
+                <label
+                  htmlFor="email"
+                  className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted"
                 >
-                  {error}
-                </motion.p>
-              )}
-            </div>
+                  Email
+                </label>
+                <InputField
+                  id="email"
+                  type="email"
+                  placeholder="seuemail@exemplo.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  autoComplete="email"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  inputMode="email"
+                />
+              </div>
 
-            {/* Actions */}
-            <div className="pt-1 space-y-4">
-              <button
-                type="submit"
-                disabled={!canSubmit}
-                className={[
-                  'w-full h-11 rounded-2xl font-semibold',
-                  'bg-gradient-to-b from-white/85 to-white/65',
-                  'border border-white/80 ring-1 ring-slate-900/5',
-                  'text-slate-900 shadow-[0_10px_28px_rgba(2,6,23,0.12)]',
-                  'disabled:opacity-50 hover:to-white/75 active:translate-y-[0.5px]',
-                  'focus:outline-none focus:ring-2 focus:ring-slate-700/10',
-                ].join(' ')}
-              >
-                {loading ? 'Entrando…' : 'Entrar'}
-              </button>
+              <div className="space-y-2">
+                <label
+                  htmlFor="password"
+                  className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted"
+                >
+                  Senha
+                </label>
+                <div className="relative">
+                  <InputField
+                    id="password"
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder="••••••••"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    autoComplete="current-password"
+                    className="pr-12"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((v) => !v)}
+                    className="absolute inset-y-0 right-2 flex items-center rounded-full px-2 text-muted transition-colors duration-200 ease-out hover:text-[color:var(--ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(59,130,246,0.24)]"
+                    aria-label={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
+                    title={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
+                  >
+                    {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                  </button>
+                </div>
+              </div>
 
-              <button
-                type="button"
-                onClick={() => navigate('/register')}
-                disabled={loading}
-                className={[
-                  'w-full h-11 rounded-2xl font-semibold',
-                  'bg-white/70 backdrop-blur-xl',
-                  'border border-white/80 ring-1 ring-slate-900/5',
-                  'text-slate-900 shadow-[0_10px_28px_rgba(2,6,23,0.10)]',
-                  'hover:bg-white/80 active:translate-y-[0.5px]',
-                  'focus:outline-none focus:ring-2 focus:ring-slate-700/10',
-                ].join(' ')}
-              >
-                Criar perfil
-              </button>
+              <div role="status" aria-live="polite" className="min-h-[1.25rem] text-center">
+                {error && (
+                  <motion.p
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    className="text-sm font-medium text-rose-500"
+                  >
+                    {error}
+                  </motion.p>
+                )}
+              </div>
 
-              <Divider />
+              <div className="space-y-4 pt-2">
+                <GlassButton
+                  type="submit"
+                  disabled={!canSubmit}
+                  className="h-12 w-full justify-center text-base"
+                >
+                  {loading ? 'Entrando…' : 'Entrar'}
+                </GlassButton>
 
-              <button
-                type="button"
-                onClick={() => setIsTourActive(true)}
-                disabled={loading}
-                className={[
-                  'w-full h-11 rounded-2xl font-semibold',
-                  'bg-white/70 backdrop-blur-xl',
-                  'border border-white/80 ring-1 ring-slate-900/5',
-                  'text-slate-900 shadow-[0_10px_28px_rgba(2,6,23,0.10)]',
-                  'hover:bg-white/80 active:translate-y-[0.5px]',
-                  'focus:outline-none focus:ring-2 focus:ring-slate-700/10',
-                ].join(' ')}
-              >
-                Iniciar Tour
-              </button>
-            </div>
-          </form>
-        </motion.div>
+                <GlassButton
+                  type="button"
+                  variant="subtle"
+                  disabled={loading}
+                  onClick={() => navigate('/register')}
+                  className="h-12 w-full justify-center text-base"
+                >
+                  Criar perfil
+                </GlassButton>
+
+                <Divider />
+
+                <GlassButton
+                  type="button"
+                  variant="subtle"
+                  disabled={loading}
+                  onClick={() => setIsTourActive(true)}
+                  className="h-12 w-full justify-center text-base"
+                >
+                  Fazer tour guiado
+                </GlassButton>
+              </div>
+            </form>
+          </SurfaceCard>
+        </motion.section>
       </div>
     </PhoneFrame>
   );

--- a/src/pages/memory/__tests__/useMemoryPageData.test.ts
+++ b/src/pages/memory/__tests__/useMemoryPageData.test.ts
@@ -1,0 +1,121 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { useMemoryPageData } from '../useMemoryPageData';
+import type { Memoria } from '../../../api/memoriaApi';
+
+vi.mock('../../../api/memoriaApi', async () => {
+  const actual = await vi.importActual<typeof import('../../../api/memoriaApi')>(
+    '../../../api/memoriaApi'
+  );
+  return {
+    ...actual,
+    buscarMemoriasPorUsuario: vi.fn(),
+  };
+});
+
+vi.mock('../../../api/perfilApi', () => ({
+  buscarPerfilEmocional: vi.fn(),
+}));
+
+vi.mock('../../../api/relatorioEmocionalApi', () => ({
+  buscarRelatorioEmocional: vi.fn(),
+}));
+
+const { buscarMemoriasPorUsuario } = await import('../../../api/memoriaApi');
+const { buscarPerfilEmocional } = await import('../../../api/perfilApi');
+const { buscarRelatorioEmocional } = await import('../../../api/relatorioEmocionalApi');
+
+describe('useMemoryPageData', () => {
+  const memories: Memoria[] = [
+    {
+      id: '1',
+      usuario_id: 'user',
+      mensagem_id: null,
+      resumo_eco: 'Resumo',
+      created_at: '2024-05-15T00:00:00Z',
+      emocao_principal: 'Alegria',
+      intensidade: 7,
+      analise_resumo: 'Feliz com o trabalho',
+      tags: ['trabalho'],
+      salvar_memoria: true,
+    },
+    {
+      id: '2',
+      usuario_id: 'user',
+      mensagem_id: null,
+      resumo_eco: 'Resumo',
+      created_at: '2024-05-14T00:00:00Z',
+      emocao_principal: 'Raiva',
+      intensidade: 2,
+      analise_resumo: 'Discussão com amigo',
+      tags: ['amizade'],
+      salvar_memoria: false,
+    },
+  ];
+
+  const perfil = {
+    emocoes_frequentes: { Alegria: 5, Tristeza: 2 },
+    temas_recorrentes: { trabalho: 3 },
+  };
+
+  const relatorio = {
+    mapa_emocional: [
+      { emocao: 'Alegria', valencia: 0.6, excitacao: 0.2 },
+      { emocao: 'Raiva', valencia: -0.4, excitacao: 0.7 },
+    ],
+    linha_do_tempo_intensidade: [
+      { data: '2024-05-15', intensidade: 7 },
+    ],
+    total_memorias: 1,
+  };
+
+  beforeEach(() => {
+    (buscarMemoriasPorUsuario as any).mockResolvedValue(memories);
+    (buscarPerfilEmocional as any).mockResolvedValue(perfil);
+    (buscarRelatorioEmocional as any).mockResolvedValue(relatorio);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads memories and derived data for a user', async () => {
+    const { result } = renderHook(() => useMemoryPageData('user'));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.filteredMemories).toHaveLength(1);
+    expect(result.current.filteredMemories[0].id).toBe('1');
+    expect(result.current.emotionChart[0]).toEqual({ name: 'Alegria', value: 5 });
+    expect(result.current.themeChart[0]).toEqual({ name: 'trabalho', value: 3 });
+    expect(result.current.mapaEmocional2D).toHaveLength(2);
+  });
+
+  it('resets filters and applies query filter', async () => {
+    const { result } = renderHook(() => useMemoryPageData('user'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.setMinIntensity(8);
+      result.current.setQuery('trabalho');
+    });
+
+    expect(result.current.filteredMemories).toHaveLength(0);
+
+    act(() => {
+      result.current.resetFilters();
+    });
+
+    expect(result.current.filteredMemories).toHaveLength(1);
+  });
+
+  it('skips fetch when user is missing', async () => {
+    const { result } = renderHook(() => useMemoryPageData(null));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(buscarMemoriasPorUsuario).not.toHaveBeenCalled();
+    expect(result.current.filteredMemories).toHaveLength(0);
+  });
+});

--- a/src/pages/memory/components/MemoryCard.tsx
+++ b/src/pages/memory/components/MemoryCard.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import type { Memoria } from '../../../api/memoriaApi';
+import {
+  generateConsistentPastelColor,
+  getEmotionColor,
+  humanDate,
+} from '../../../utils/memory';
+import { motion } from 'framer-motion';
+
+type Props = {
+  mem: Memoria;
+};
+
+const capitalize = (value?: string | null) =>
+  value ? value.charAt(0).toUpperCase() + value.slice(1) : '';
+
+const MemoryCard: React.FC<Props> = ({ mem }) => {
+  const [open, setOpen] = useState(false);
+
+  const color = getEmotionColor(mem.emocao_principal || 'neutro');
+  const when = mem.created_at ? humanDate(mem.created_at) : '';
+  const intensidade = Math.max(0, Math.min(10, Number((mem as any).intensidade ?? 0)));
+  const preview = (mem.analise_resumo || mem.contexto || '').trim();
+
+  return (
+    <li className="rounded-3xl border border-black/10 bg-white/70 backdrop-blur-md shadow-md p-4 transition-all">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="w-full text-left"
+      >
+        <div className="flex items-center gap-3">
+          <span
+            className="h-9 w-9 rounded-full ring-2 ring-white/70 shadow-sm shrink-0"
+            style={{ background: color, boxShadow: 'inset 0 1px 0 rgba(255,255,255,.6)' }}
+            aria-hidden
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-[15px] font-semibold text-neutral-900 truncate">
+                {capitalize(mem.emocao_principal) || 'Emoção'}
+              </h3>
+              <span className="text-[12px] text-neutral-500 shrink-0">{when}</span>
+            </div>
+
+            {preview && (
+              <p
+                className="text-sm text-neutral-700 mt-0.5"
+                style={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {preview}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-3 h-1.5 rounded-full bg-neutral-200/60 overflow-hidden">
+          <span
+            className="block h-full rounded-full"
+            style={{
+              width: `${(intensidade / 10) * 100}%`,
+              background: `linear-gradient(90deg, ${color}, rgba(0,0,0,0.08))`,
+            }}
+            aria-hidden
+          />
+        </div>
+
+        {!!mem.tags?.length && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {mem.tags.map((tag, i) => (
+              <span
+                key={`${tag}-${i}`}
+                className="text-xs px-3 py-1 rounded-full font-medium border border-black/10 shadow-sm"
+                style={{ background: generateConsistentPastelColor(tag), color: '#0f172a' }}
+              >
+                {tag && tag[0].toUpperCase() + tag.slice(1)}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-3 flex justify-end">
+          <span className="text-xs font-medium text-sky-700">{open ? 'Fechar ↑' : 'Ver mais ↓'}</span>
+        </div>
+      </button>
+
+      {open && (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="space-y-4 mt-3 pt-3 border-t border-neutral-200 text-sm text-neutral-700"
+        >
+          {mem.analise_resumo && (
+            <div className="rounded-xl p-3 bg-white/70 backdrop-blur border border-neutral-200 shadow-sm">
+              <div className="font-semibold mb-1 text-neutral-900">Reflexão da Eco</div>
+              <div>{mem.analise_resumo}</div>
+            </div>
+          )}
+
+          {mem.contexto && (
+            <div className="rounded-xl p-3 bg-white/70 backdrop-blur border border-neutral-200 shadow-sm">
+              <div className="font-semibold mb-1 text-neutral-900">Seu pensamento</div>
+              <div>{mem.contexto}</div>
+            </div>
+          )}
+
+          {(mem.dominio_vida || mem.categoria) && (
+            <div className="flex flex-col sm:flex-row gap-2">
+              {mem.dominio_vida && (
+                <div className="flex-1 rounded-xl p-3 bg-white/70 backdrop-blur border border-neutral-200 shadow-sm">
+                  <div className="font-semibold mb-1 text-neutral-900">Domínio</div>
+                  <div>{mem.dominio_vida}</div>
+                </div>
+              )}
+              {mem.categoria && (
+                <div className="flex-1 rounded-xl p-3 bg-white/70 backdrop-blur border border-neutral-200 shadow-sm">
+                  <div className="font-semibold mb-1 text-neutral-900">Categoria</div>
+                  <div>{mem.categoria}</div>
+                </div>
+              )}
+            </div>
+          )}
+        </motion.div>
+      )}
+    </li>
+  );
+};
+
+export default MemoryCard;

--- a/src/pages/memory/components/__tests__/MemoryCard.test.tsx
+++ b/src/pages/memory/components/__tests__/MemoryCard.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import MemoryCard from '../MemoryCard';
+import type { Memoria } from '../../../../api/memoriaApi';
+
+describe('MemoryCard', () => {
+  const baseMemory: Memoria = {
+    id: '1',
+    usuario_id: 'user',
+    mensagem_id: null,
+    resumo_eco: 'Resumo',
+    created_at: '2024-05-10T00:00:00Z',
+    emocao_principal: 'Alegria',
+    intensidade: 7,
+    contexto: 'Contexto da memória',
+    analise_resumo: 'Resumo analítico',
+    tags: ['trabalho', 'família'],
+  };
+
+  it('renders collapsed card with emotion, preview and tags', () => {
+    render(<MemoryCard mem={baseMemory} />);
+
+    expect(screen.getByRole('heading', { name: /alegria/i })).toBeInTheDocument();
+    expect(screen.getByText('Resumo analítico')).toBeInTheDocument();
+    expect(screen.getByText(/trabalho/i)).toBeInTheDocument();
+    expect(screen.getByText(/família/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ver mais/)).toBeInTheDocument();
+  });
+
+  it('expands to show details when toggled', () => {
+    render(<MemoryCard mem={baseMemory} />);
+
+    const toggle = screen.getByRole('button', { name: /ver mais/i });
+    fireEvent.click(toggle);
+
+    expect(screen.getAllByText('Resumo analítico')).toHaveLength(2);
+    expect(screen.getByText('Contexto da memória')).toBeInTheDocument();
+    expect(screen.getByText('Seu pensamento')).toBeInTheDocument();
+    expect(screen.getByText('Reflexão da Eco')).toBeInTheDocument();
+    expect(screen.getByText(/Fechar/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/memory/useMemoryPageData.ts
+++ b/src/pages/memory/useMemoryPageData.ts
@@ -1,0 +1,193 @@
+import { useEffect, useMemo, useState } from 'react';
+import { buscarMemoriasPorUsuario, Memoria } from '../../api/memoriaApi';
+import { buscarPerfilEmocional } from '../../api/perfilApi';
+import {
+  buscarRelatorioEmocional,
+  RelatorioEmocional,
+} from '../../api/relatorioEmocionalApi';
+import {
+  FILTER_GROUP_ORDER,
+  filtersAreActive,
+  generateConsistentPastelColor,
+  getEmotionColor,
+  groupMemories,
+  normalize,
+  normalizeTextFields,
+  clamp,
+} from '../../utils/memory';
+
+export type TabKey = 'memories' | 'profile' | 'report';
+
+export type EmotionChartDatum = { name: string; value: number };
+
+export const normalizeTab = (tab?: string): TabKey => {
+  if (tab === 'profile') return 'profile';
+  if (tab === 'report') return 'report';
+  return 'memories';
+};
+
+const savedOnly = (memory: Memoria) => {
+  const flag = (memory as any).salvar_memoria;
+  if (flag === undefined || flag === null) return true;
+  if (typeof flag === 'string') return flag === 'true';
+  if (typeof flag === 'number') return flag === 1;
+  return Boolean(flag);
+};
+
+export function useMemoryPageData(userId?: string | null) {
+  const [memories, setMemories] = useState<Memoria[]>([]);
+  const [perfil, setPerfil] = useState<any>(null);
+  const [relatorio, setRelatorio] = useState<RelatorioEmocional | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [emoFilter, setEmoFilter] = useState<string>('all');
+  const [query, setQuery] = useState<string>('');
+  const [minIntensity, setMinIntensity] = useState<number>(0);
+
+  useEffect(() => {
+    if (!userId) {
+      setMemories([]);
+      setPerfil(null);
+      setRelatorio(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const [memData, perfilData, relatorioData] = await Promise.all([
+          buscarMemoriasPorUsuario(userId),
+          buscarPerfilEmocional(userId),
+          buscarRelatorioEmocional(userId),
+        ]);
+        if (cancelled) return;
+        setMemories(memData.filter(savedOnly));
+        setPerfil(perfilData);
+        setRelatorio(relatorioData);
+      } catch (err) {
+        if (cancelled) return;
+        setError('Erro ao carregar dados.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const emotionOptions = useMemo(() => {
+    const unique = new Set<string>();
+    memories.forEach((memory) => {
+      if (memory.emocao_principal) unique.add(memory.emocao_principal);
+    });
+    return Array.from(unique).sort((a, b) => a.localeCompare(b));
+  }, [memories]);
+
+  const filteredMemories = useMemo(() => {
+    const normalizedQuery = normalize(query);
+
+    return memories.filter((memory) => {
+      if (emoFilter !== 'all') {
+        if (normalize(memory.emocao_principal || '') !== normalize(emoFilter)) return false;
+      }
+
+      const intensity = Number((memory as any).intensidade ?? 0);
+      if (!Number.isNaN(minIntensity) && intensity < minIntensity) return false;
+
+      if (normalizedQuery) {
+        const haystack = normalizeTextFields(
+          memory.analise_resumo,
+          memory.contexto,
+          Array.isArray(memory.tags) ? memory.tags.join(' ') : ''
+        );
+        if (!haystack.includes(normalizedQuery)) return false;
+      }
+
+      return true;
+    });
+  }, [memories, emoFilter, minIntensity, query]);
+
+  const groupedMemories = useMemo(() => groupMemories(filteredMemories), [filteredMemories]);
+
+  const emotionChart: EmotionChartDatum[] = useMemo(() => {
+    if (!perfil?.emocoes_frequentes) return [];
+    return Object.entries(perfil.emocoes_frequentes)
+      .map(([name, value]) => ({ name, value: Number(value) }))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 5);
+  }, [perfil]);
+
+  const themeChart: EmotionChartDatum[] = useMemo(() => {
+    if (!perfil?.temas_recorrentes) return [];
+    return Object.entries(perfil.temas_recorrentes)
+      .map(([name, value]) => ({ name, value: Number(value) }))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 5);
+  }, [perfil]);
+
+  const mapaEmocional2D = useMemo(() => {
+    if (!Array.isArray(relatorio?.mapa_emocional)) return [];
+    return relatorio.mapa_emocional
+      .map((point: any) => ({
+        emocao: point.emocao ?? point.emocao_principal ?? 'Desconhecida',
+        valenciaNormalizada: clamp(
+          typeof point.valencia === 'number' ? point.valencia : point.x ?? 0
+        ),
+        excitacaoNormalizada: clamp(
+          typeof point.excitacao === 'number' ? point.excitacao : point.y ?? 0
+        ),
+        cor: point.cor ?? undefined,
+      }))
+      .filter(
+        (point: any) =>
+          typeof point.valenciaNormalizada === 'number' &&
+          typeof point.excitacaoNormalizada === 'number'
+      );
+  }, [relatorio]);
+
+  const filtersActive = useMemo(
+    () => filtersAreActive(emoFilter, query, minIntensity),
+    [emoFilter, query, minIntensity]
+  );
+
+  const resetFilters = () => {
+    setEmoFilter('all');
+    setQuery('');
+    setMinIntensity(0);
+  };
+
+  return {
+    loading,
+    error,
+    memories,
+    perfil,
+    relatorio,
+    emotionOptions,
+    filteredMemories,
+    groupedMemories,
+    emotionChart,
+    themeChart,
+    mapaEmocional2D,
+    filtersActive,
+    resetFilters,
+    emoFilter,
+    setEmoFilter,
+    query,
+    setQuery,
+    minIntensity,
+    setMinIntensity,
+  };
+}
+
+export const groupOrder = Array.from(FILTER_GROUP_ORDER);
+
+export const chartColorForEmotion = (emotion: string) => getEmotionColor(emotion);
+
+export const chartColorForTheme = (theme: string) => generateConsistentPastelColor(theme);

--- a/src/utils/__tests__/memory.test.ts
+++ b/src/utils/__tests__/memory.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import {
+  bucketLabelForDate,
+  clamp,
+  filtersAreActive,
+  generateConsistentPastelColor,
+  getEmotionColor,
+  groupMemories,
+  humanDate,
+  normalize,
+  normalizeTextFields,
+} from '../memory';
+import type { Memoria } from '../../api/memoriaApi';
+
+const mockNow = new Date('2024-05-15T12:00:00Z');
+
+describe('memory utils', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('normalizes text and removes diacritics', () => {
+    expect(normalize('Ânimo')).toBe('animo');
+    expect(normalizeTextFields('Olá', null, 'Mundo')).toBe('ola mundo');
+  });
+
+  it('generates consistent colors for unknown emotions', () => {
+    const pastel = generateConsistentPastelColor('empolgado');
+    expect(pastel.startsWith('hsl(')).toBe(true);
+    expect(getEmotionColor('empolgado')).toBe(pastel);
+    expect(getEmotionColor('Alegria')).toBe('#3B82F6');
+  });
+
+  it('formats human readable dates', () => {
+    expect(humanDate('2024-05-15T03:00:00Z')).toBe('Hoje');
+    expect(humanDate('2024-05-14T03:00:00Z')).toBe('Ontem');
+    expect(humanDate('2024-05-10T03:00:00Z')).toBe('5 dias atrás');
+  });
+
+  it('labels buckets for recency', () => {
+    expect(bucketLabelForDate('2024-05-15T01:00:00Z')).toBe('Hoje');
+    expect(bucketLabelForDate('2024-05-14T10:00:00Z')).toBe('Ontem');
+    expect(bucketLabelForDate('2024-05-13T03:00:00Z')).toBe('Esta semana');
+    expect(bucketLabelForDate('2024-05-02T03:00:00Z')).toBe('Este mês');
+    expect(bucketLabelForDate('2024-04-02T03:00:00Z')).toBe('Antigas');
+  });
+
+  it('groups memories by bucket', () => {
+    const memories: Memoria[] = [
+      { id: '1', usuario_id: '1', mensagem_id: null, resumo_eco: '', created_at: '2024-05-15T00:00:00Z' },
+      { id: '2', usuario_id: '1', mensagem_id: null, resumo_eco: '', created_at: '2024-05-14T00:00:00Z' },
+      { id: '3', usuario_id: '1', mensagem_id: null, resumo_eco: '', created_at: '2024-04-10T00:00:00Z' },
+    ];
+    const grouped = groupMemories(memories);
+    expect(Object.keys(grouped)).toContain('Hoje');
+    expect(grouped['Hoje']).toHaveLength(1);
+    expect(grouped['Ontem']).toHaveLength(1);
+    expect(grouped['Antigas']).toHaveLength(1);
+  });
+
+  it('checks filter activeness', () => {
+    expect(filtersAreActive('all', '', 0)).toBe(false);
+    expect(filtersAreActive('raiva', '', 0)).toBe(true);
+    expect(filtersAreActive('all', 'busca', 0)).toBe(true);
+    expect(filtersAreActive('all', '', 3)).toBe(true);
+  });
+
+  it('clamps values between min and max', () => {
+    expect(clamp(2)).toBe(1);
+    expect(clamp(-2)).toBe(-1);
+    expect(clamp(0.5)).toBe(0.5);
+  });
+});

--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -1,0 +1,99 @@
+import { Memoria } from '../api/memoriaApi';
+
+export const EMOTION_COLORS: Record<string, string> = {
+  raiva: '#DB2777',
+  irritado: '#EC4899',
+  frustracao: '#BE185D',
+  medo: '#DB2777',
+  incerteza: '#BE185D',
+  alegria: '#3B82F6',
+  calmo: '#2563EB',
+  surpresa: '#3B82F6',
+  antecipacao: '#2563EB',
+  tristeza: '#A855F7',
+  neutro: '#8B5CF6',
+};
+
+export const normalize = (value: string = ''): string =>
+  value.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+export const hashStringToHue = (value: string): number => {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = value.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return Math.abs(hash) % 360;
+};
+
+export const generateConsistentPastelColor = (
+  seed: string,
+  options: { saturation?: number; lightness?: number } = {}
+): string => {
+  const hue = hashStringToHue(seed);
+  const { saturation = 25, lightness = 88 } = options;
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+};
+
+export const getEmotionColor = (emotionName: string): string => {
+  const normalized = normalize(emotionName);
+  return EMOTION_COLORS[normalized] || generateConsistentPastelColor(emotionName);
+};
+
+export const humanDate = (raw: string): string => {
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return '';
+
+  const diffInDays = Math.floor((Date.now() - date.getTime()) / 86_400_000);
+  if (diffInDays === 0) return 'Hoje';
+  if (diffInDays === 1) return 'Ontem';
+  return `${diffInDays} dias atrás`;
+};
+
+export const clamp = (value: number, min = -1, max = 1): number =>
+  Math.max(min, Math.min(max, value));
+
+export const bucketLabelForDate = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return 'Antigas';
+
+  const now = new Date();
+  const diffDays = Math.floor((+now - +date) / 86_400_000);
+  if (diffDays === 0) return 'Hoje';
+  if (diffDays === 1) return 'Ontem';
+
+  const startOfWeek = new Date(now);
+  const day = startOfWeek.getDay();
+  const diffToMonday = (day + 6) % 7;
+  startOfWeek.setHours(0, 0, 0, 0);
+  startOfWeek.setDate(startOfWeek.getDate() - diffToMonday);
+  if (date >= startOfWeek) return 'Esta semana';
+
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  if (date >= startOfMonth) return 'Este mês';
+
+  return 'Antigas';
+};
+
+export type GroupedMemories = Record<string, Memoria[]>;
+
+export const groupMemories = (memories: Memoria[]): GroupedMemories =>
+  memories.reduce<GroupedMemories>((acc, memory) => {
+    const label = memory.created_at ? bucketLabelForDate(memory.created_at) : 'Antigas';
+    if (!acc[label]) acc[label] = [];
+    acc[label].push(memory);
+    return acc;
+  }, {});
+
+export const FILTER_GROUP_ORDER = ['Hoje', 'Ontem', 'Esta semana', 'Este mês', 'Antigas'] as const;
+
+export const filtersAreActive = (
+  emotionFilter: string,
+  searchQuery: string,
+  minIntensity: number
+): boolean => emotionFilter !== 'all' || !!searchQuery || minIntensity > 0;
+
+export const normalizeTextFields = (...values: (string | null | undefined)[]): string =>
+  values
+    .map((value) => (value ? normalize(value) : ''))
+    .filter(Boolean)
+    .join(' ');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,92 +1,43 @@
 /** @type {import('tailwindcss').Config} */
-import plugin from 'tailwindcss/plugin'
-
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
-      /* Tipografia — SF Pro com fallbacks (Inter fica como fallback também) */
       fontFamily: {
         sans: [
-          'SF Pro Display','SF Pro Text',       // macOS/iOS
-          '-apple-system','BlinkMacSystemFont', // Apple stack
-          'Segoe UI','Inter','system-ui','Roboto',
-          'Helvetica Neue','Arial','sans-serif'
+          'SF Pro Display',
+          'SF Pro Text',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'Segoe UI',
+          'system-ui',
+          'Helvetica Neue',
+          'Arial',
+          'sans-serif',
         ],
       },
-
-      /* Sua paleta azul mantida */
       colors: {
-        blue: {
-          50:  '#f0f7ff',
-          100: '#e0effe',
-          200: '#bae1fd',
-          300: '#7dcefc',
-          400: '#38b7f8',
-          500: '#0e9de9',
-          600: '#0280c7',
-          700: '#0267a1',
-          800: '#065786',
-          900: '#0a4970',
+        ink: 'var(--ink)',
+        muted: 'var(--muted)',
+        surface: {
+          DEFAULT: 'var(--surface)',
+          strong: 'var(--surface-strong)',
         },
       },
-
-      /* Gradientes de fundo “Visa vibe” (opcional de usar) */
-      backgroundImage: {
-        'eco-vibe':
-          'radial-gradient(1200px_600px_at_20%_-10%,#E9E8FF,transparent_55%),' +
-          'radial-gradient(900px_600px_at_85%_-5%,#FFE7E1,transparent_60%),' +
-          'linear-gradient(120deg,#EEF3FF_0%,#FFF8F3_70%)',
+      boxShadow: {
+        'soft-xs': 'var(--shadow-xs)',
+        'soft-lg': 'var(--shadow-lg)',
       },
-
-      /* Animações já existentes */
-      keyframes: {
-        ripple: {
-          '0%':   { transform: 'scale(0.8)', opacity: '1' },
-          '100%': { transform: 'scale(1.4)', opacity: '0' },
-        },
-        pulseListen: {
-          '0%, 100%': { transform: 'scale(1)', opacity: '1' },
-          '50%':      { transform: 'scale(1.08)', opacity: '0.85' },
-        },
-        pulseTalk: {
-          '0%':   { transform: 'scale(1)', opacity: '1' },
-          '25%':  { transform: 'scale(1.06)', opacity: '0.85' },
-          '50%':  { transform: 'scale(1)', opacity: '1' },
-          '100%': { transform: 'scale(1)', opacity: '1' },
-        },
+      maxWidth: {
+        'chat-container': 'var(--max-chat-width)',
       },
-      animation: {
-        ripple: 'ripple 1.5s infinite ease-in-out',
-        pulseListen: 'pulseListen 1.2s ease-in-out infinite',
-        pulseTalk: 'pulseTalk 3s ease-in-out infinite',
+      spacing: {
+        safe: 'var(--safe-bottom)',
+      },
+      transitionTimingFunction: {
+        'swift-out': 'cubic-bezier(0.22, 1, 0.36, 1)',
       },
     },
   },
-
-  /* Utilitários prontos de vidro */
-  plugins: [
-    plugin(function ({ addUtilities }) {
-      addUtilities({
-        /* cartão de vidro forte (para sidebar/topbar/cards principais) */
-        '.glass': {
-          'background-color': 'rgba(255,255,255,0.10)',
-          'backdrop-filter': 'blur(24px)',
-          '-webkit-backdrop-filter': 'blur(24px)',
-          'border': '1px solid rgba(255,255,255,0.30)',
-          'box-shadow':
-            '0 10px 30px rgba(16,24,40,0.10), inset 0 1px 0 rgba(255,255,255,0.35)',
-        },
-        /* vidro suave (para botões/chips) */
-        '.glass-soft': {
-          'background-color': 'rgba(255,255,255,0.12)',
-          'backdrop-filter': 'blur(18px)',
-          '-webkit-backdrop-filter': 'blur(18px)',
-          'border': '1px solid rgba(255,255,255,0.25)',
-          'box-shadow':
-            '0 6px 20px rgba(16,24,40,0.08), inset 0 1px 0 rgba(255,255,255,0.30)',
-        },
-      })
-    }),
-  ],
-}
+  plugins: [],
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    css: false,
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- introduce SF Pro themed glass primitives and global tokens to support the white-on-white Apple aesthetic
- refresh the login and chat flows with centered glass layouts, message virtualization, lazy-loaded audio, and abortable/retried requests
- add preconnect hints for backend services and tune Tailwind/theme configuration for the new surface styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6e0610ae083258aefc085ad7f29f0