### PR TITLE
Refine chat UI with SF Pro styling and responsive layout

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -226,10 +226,10 @@ const ChatInput: React.FC<Props> = ({
         handleSend();
       }}
       className={`
-        relative w-full px-3 py-1.5 rounded-3xl
-        border border-white/45 bg-white/55 backdrop-blur-2xl
-        shadow-[0_16px_46px_rgba(16,24,40,0.10),inset_0_1px_0_rgba(255,255,255,0.55)]
-        transition-all duration-200 ${disabled ? 'opacity-90' : ''}
+        relative w-full px-3 py-1.5 md:px-4 md:py-2 rounded-[28px]
+        border border-white/60 bg-white/80 backdrop-blur-2xl
+        shadow-[0_18px_48px_rgba(15,23,42,0.12),inset_0_1px_0_rgba(255,255,255,0.6)]
+        ring-1 ring-white/40 transition-all duration-200 ${disabled ? 'opacity-90' : ''}
       `}
       initial={{ y: 50, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
@@ -246,11 +246,10 @@ const ChatInput: React.FC<Props> = ({
             type="button"
             onClick={() => setShowMoreOptions((prev) => !prev)}
             className="
-              w-9 h-9 rounded-full
-              border border-white/45 bg-white/40 backdrop-blur-xl
-              shadow-sm flex items-center justify-center
-              hover:bg-white/55 active:scale-[0.98] transition
-              disabled:opacity-50
+              flex h-9 w-9 items-center justify-center rounded-full
+              border border-white/60 bg-white/75 backdrop-blur-xl
+              shadow-[0_6px_16px_rgba(15,23,42,0.08)] transition
+              hover:bg-white active:scale-[0.98] disabled:opacity-50
             "
             aria-expanded={showMoreOptions}
             aria-controls="chatinput-popover"
@@ -272,9 +271,9 @@ const ChatInput: React.FC<Props> = ({
               exit={{ opacity: 0, y: 10 }}
               transition={{ duration: 0.2 }}
               className="
-                absolute bottom-full mb-2 left-2 w-56 z-50
-                rounded-2xl border border-white/45 bg-white/70 backdrop-blur-2xl
-                shadow-[0_20px_50px_rgba(16,24,40,0.12),inset_0_1px_0_rgba(255,255,255,0.55)]
+                absolute bottom-full left-2 z-50 mb-2 w-56
+                rounded-2xl border border-white/60 bg-white/80 backdrop-blur-2xl
+                shadow-[0_24px_60px_rgba(15,23,42,0.14),inset_0_1px_0_rgba(255,255,255,0.6)]
                 p-1.5
               "
             >
@@ -323,9 +322,8 @@ const ChatInput: React.FC<Props> = ({
             aria-disabled={disabled}
             aria-label="Escreva sua mensagem"
             className="
-              w-full min-w-0 resize-none bg-transparent border-none focus:outline-none
-              leading-[1.35] py-2 max-h-48 overflow-y-auto
-              text-[15px] md:text-base text-slate-800 placeholder:text-slate-500 placeholder:font-light
+              w-full min-w-0 max-h-48 resize-none overflow-y-auto border-none bg-transparent py-2 leading-[1.42] tracking-tight
+              text-[15px] md:text-base text-slate-800 placeholder:text-slate-400 placeholder:font-light focus:outline-none
             "
           />
         </div>
@@ -337,11 +335,10 @@ const ChatInput: React.FC<Props> = ({
             onClick={startRecording}
             disabled={disabled}
             className="
-              w-9 h-9 rounded-full
-              border border-white/45 bg-white/40 backdrop-blur-xl
-              shadow-sm flex items-center justify-center
-              hover:bg-white/55 active:scale-[0.98] transition
-              disabled:opacity-50
+              flex h-9 w-9 items-center justify-center rounded-full
+              border border-white/60 bg-white/75 backdrop-blur-xl
+              shadow-[0_6px_16px_rgba(15,23,42,0.08)] transition
+              hover:bg-white active:scale-[0.98] disabled:opacity-50
             "
             aria-label="Iniciar gravação"
           >
@@ -353,11 +350,10 @@ const ChatInput: React.FC<Props> = ({
             ref={sendButtonRef}
             disabled={disabled || !inputMessage.trim()}
             className="
-              w-9 h-9 rounded-full
-              backdrop-blur-xl bg-white/85 border border-white/60
-              shadow-sm hover:bg-white active:scale-[0.98]
-              transition disabled:opacity-50 disabled:cursor-not-allowed
-              text-slate-700
+              flex h-9 w-9 items-center justify-center rounded-full text-slate-700
+              border border-white/70 bg-white/90 backdrop-blur-xl
+              shadow-[0_8px_22px_rgba(15,23,42,0.12)] transition
+              hover:bg-white active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50
             "
             aria-label="Enviar mensagem"
           >

--- a/src/components/EcoBubbleIcon.tsx
+++ b/src/components/EcoBubbleIcon.tsx
@@ -8,19 +8,32 @@ type Props = {
 const EcoBubbleIcon: React.FC<Props> = ({ size = 24, className }) => {
   return (
     <div
-      className={`rounded-full shadow-md ring-1 ring-[rgba(200,220,255,0.45)] ${className || ''}`}
+      className={`relative rounded-full ${className || ''}`}
       style={{
         width: size,
         height: size,
         background:
-          'radial-gradient(circle at 30% 30%, rgba(255,255,255,0.88), rgba(240,240,255,0.45))',
-        border: '1px solid rgba(200, 220, 255, 0.45)',
-        boxShadow: '0 6px 18px rgba(0, 0, 0, 0.10)', // presença um pouco maior
-        backdropFilter: 'blur(8px)',
-        WebkitBackdropFilter: 'blur(8px)',
+          'radial-gradient(115% 115% at 30% 25%, rgba(255,255,255,0.95), rgba(228,237,255,0.45))',
+        border: '1px solid rgba(168, 196, 255, 0.55)',
+        boxShadow:
+          '0 10px 26px rgba(43, 63, 122, 0.16), inset 0 0 12px rgba(255,255,255,0.35)',
+        backdropFilter: 'blur(10px)',
+        WebkitBackdropFilter: 'blur(10px)',
       }}
       aria-hidden
-    />
+    >
+      <span
+        className="absolute inset-0 rounded-full"
+        style={{
+          background:
+            'radial-gradient(80% 80% at 70% 30%, rgba(134,173,255,0.28), transparent)',
+          filter: 'blur(6px)',
+          opacity: 0.9,
+          pointerEvents: 'none',
+        }}
+        aria-hidden
+      />
+    </div>
   );
 };
 

--- a/src/components/TypingDots.tsx
+++ b/src/components/TypingDots.tsx
@@ -10,9 +10,9 @@ type Props = {
 };
 
 const SIZES = {
-  sm: { dot: 6, gap: 6, padX: 8, padY: 6, radius: "rounded-xl" },
-  md: { dot: 8, gap: 8, padX: 12, padY: 8, radius: "rounded-2xl" },
-  lg: { dot: 10, gap: 10, padX: 14, padY: 10, radius: "rounded-3xl" },
+  sm: { dot: 7, gap: 8, padX: 10, padY: 7, radius: "rounded-xl" },
+  md: { dot: 9, gap: 11, padX: 14, padY: 9, radius: "rounded-2xl" },
+  lg: { dot: 11, gap: 14, padX: 18, padY: 11, radius: "rounded-3xl" },
 };
 
 const dotTransition = {
@@ -36,7 +36,7 @@ const TypingDots: React.FC<Props> = ({
           role="presentation"
           className="inline-block rounded-full bg-slate-400/70 dark:bg-slate-300/70"
           style={{ width: s.dot, height: s.dot }}
-          animate={{ y: [0, -3, 0], opacity: [0.7, 1, 0.7] }}
+          animate={{ y: [0, -3, 0], opacity: [0.68, 1, 0.68] }}
           transition={{ ...dotTransition, delay }}
         />
       ))}

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
 html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; text-rendering: optimizeLegibility; }
 
 body {
-  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+  font-family: 'SF Pro Text', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #ffffff;
@@ -15,7 +15,7 @@ body {
   overscroll-behavior-y: none;   /* remove bounce do body */
   font-feature-settings: "kern","liga","calt";
   font-variant-numeric: tabular-nums;
-  letter-spacing: .01em;
+  letter-spacing: .005em;
 }
 
 /* ---------------------------- Tokens ---------------------------- */
@@ -250,7 +250,7 @@ button, [role="button"], a { touch-action: manipulation; }
 
 /* Força sans dentro da bolha */
 .message-bubble, .message-bubble * {
-  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji" !important;
+  font-family: 'SF Pro Text', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
 }
 
 /* Bolha de vidro decorativa */
@@ -297,23 +297,32 @@ button, [role="button"], a { touch-action: manipulation; }
 /* ------------------ Mensagens (glass style) ------------------- */
 .message-eco,
 .message-user {
-  padding: 10px 14px;
-  border-radius: 18px;
-  font-size: 0.95rem;
-  line-height: 1.55;
+  padding: 12px 18px;
+  border-radius: 22px;
+  font-size: 0.96rem;
+  line-height: 1.6;
+  letter-spacing: -0.01em;
   max-width: min(720px, 88vw);
   overflow-wrap: break-word;   /* consistente com .chat-bubble-base */
   word-break: normal;
   white-space: pre-wrap;       /* respeita \n do modelo */
-  transition: transform .15s ease, background-color .2s ease, border-color .2s ease, box-shadow .2s ease;
+  transition: transform .18s ease, background-color .2s ease, border-color .2s ease, box-shadow .2s ease;
   position: relative;
-  -webkit-backdrop-filter: saturate(1.2) blur(14px);
-  backdrop-filter: saturate(1.2) blur(14px);
-  box-shadow: var(--bubble-shadow);
-  border: 1px solid var(--bubble-border);
+  -webkit-backdrop-filter: saturate(1.25) blur(18px);
+  backdrop-filter: saturate(1.25) blur(18px);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.08);
 }
-.message-eco { background: var(--bubble-eco-bg); color:#0f172a; border-bottom-left-radius: 6px; }
-.message-user{ background: var(--bubble-user-bg); color:#0f172a; border-bottom-right-radius: 6px; }
+.message-eco {
+  background: radial-gradient(120% 120% at 30% 20%, rgba(255,255,255,0.94), rgba(255,255,255,0.6));
+  color:#0f172a;
+  border-bottom-left-radius: 8px;
+}
+.message-user{
+  background: radial-gradient(120% 120% at 70% 30%, rgba(255,255,255,0.92), rgba(255,255,255,0.55));
+  color:#0f172a;
+  border-bottom-right-radius: 8px;
+}
 
 /* brilho interno sutil (efeito iMessage) */
 .message-eco::before, .message-user::before{

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -316,14 +316,20 @@ const ChatPage: React.FC = () => {
   };
 
   return (
-    <div className="w-full h-[calc(100dvh-var(--eco-topbar-h,56px))] flex flex-col overflow-hidden bg-eco-vibe">
+    <div
+      className="relative flex h-[calc(100dvh-var(--eco-topbar-h,56px))] w-full flex-col overflow-hidden bg-white"
+      style={{
+        backgroundImage:
+          'radial-gradient(140% 100% at 50% 0%, rgba(236,240,255,0.65), transparent 55%), linear-gradient(180deg, #ffffff 0%, #f6f8ff 100%)',
+      }}
+    >
       {/* SCROLLER */}
       <div
         ref={scrollerRef}
         onScroll={handleScroll}
         role="feed"
         aria-busy={digitando}
-        className="chat-scroller flex-1 min-h-0 overflow-y-auto px-3 sm:px-6 [scrollbar-gutter:stable]"
+        className="chat-scroller flex-1 min-h-0 overflow-y-auto px-4 sm:px-6 lg:px-10 pb-6 [scrollbar-gutter:stable]"
         style={{
           paddingTop: 'calc(var(--eco-topbar-h,56px) + 12px)',
           WebkitOverflowScrolling: 'touch',
@@ -332,22 +338,18 @@ const ChatPage: React.FC = () => {
           touchAction: 'pan-y',
         }}
       >
-        <div className="w-full mx-auto max-w-[720px]">
+        <div className="w-full mx-auto max-w-3xl">
           {messages.length === 0 && !erroApi && (
             <div className="min-h-[calc(100svh-var(--eco-topbar-h,56px)-120px)] flex items-center justify-center">
               <motion.div className="px-4 w-full" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.28 }}>
-                {/* Saudação no mesmo grid das mensagens */}
-                <div className="grid grid-cols-[28px,1fr,28px] items-center">
-                  <div className="hidden sm:block" />
-                  <div className="col-start-2 justify-self-start text-center sm:text-left md:max-w-[680px]">
-                    <h2 className="text-4xl md:text-5xl font-light text-gray-800 leading-tight">
-                      {saudacao}, {userName}
-                    </h2>
-                    <p className="text-base md:text-lg font-light text-slate-500 mt-3">
-                      {OPENING_VARIATIONS[Math.floor(Math.random() * OPENING_VARIATIONS.length)]}
-                    </p>
-                  </div>
-                  <div />
+                {/* Saudação centralizada */}
+                <div className="flex flex-col items-center gap-3 text-center md:gap-4">
+                  <h2 className="text-[32px] font-light leading-tight text-slate-800 md:text-[40px]">
+                    {saudacao}, {userName}
+                  </h2>
+                  <p className="max-w-xl text-base font-light text-slate-500 md:text-lg">
+                    {OPENING_VARIATIONS[Math.floor(Math.random() * OPENING_VARIATIONS.length)]}
+                  </p>
                 </div>
               </motion.div>
             </div>
@@ -359,28 +361,35 @@ const ChatPage: React.FC = () => {
 
           <div className="w-full space-y-3 md:space-y-4">
             {messages.map((m) => (
-              <div key={m.id} className="grid grid-cols-[28px,1fr,28px] gap-2 items-start min-w-0">
+              <div
+                key={m.id}
+                className="grid grid-cols-[auto,1fr] items-start gap-3 min-w-0 md:grid-cols-[32px,1fr,32px]"
+              >
                 {/* ESQ: avatar só quando ECO */}
                 <div className="pt-1.5">
-                  {m.sender === 'eco' ? <EcoBubbleIcon /> : <div className="w-[28px] h-[28px]" />}
+                  {m.sender === 'eco' ? <EcoBubbleIcon /> : <div className="hidden h-[28px] w-[28px] md:block" />}
                 </div>
 
-                <div className={(m.sender === 'user' ? 'justify-self-end' : 'justify-self-start') + ' min-w-0 max-w-full'}>
+                <div
+                  className={`min-w-0 max-w-full ${
+                    m.sender === 'user' ? 'justify-self-end' : 'justify-self-start'
+                  }`}
+                >
                   {m.sender === 'eco' ? <EcoMessageWithAudio message={m as any} /> : <ChatMessage message={m} />}
                 </div>
 
                 {/* DIR: placeholder (evita “bolinha” fantasma) */}
-                <div className="pt-1.5">
-                  <div className="w-[28px] h-[28px]" />
+                <div className="hidden pt-1.5 md:block">
+                  <div className="h-[28px] w-[28px]" />
                 </div>
               </div>
             ))}
 
             {digitando && (
-              <div className="grid grid-cols-[28px,1fr,28px] gap-2 items-start min-w-0">
+              <div className="grid grid-cols-[auto,1fr] items-start gap-3 min-w-0 md:grid-cols-[32px,1fr,32px]">
                 <div className="pt-1.5"><EcoBubbleIcon /></div>
-                <div className="justify-self-start min-w-0 max-w-full"><TypingDots /></div>
-                <div className="pt-1.5"><div className="w-[28px] h-[28px]" /></div>
+                <div className="min-w-0 max-w-full justify-self-start"><TypingDots /></div>
+                <div className="hidden pt-1.5 md:block"><div className="h-[28px] w-[28px]" /></div>
               </div>
             )}
 
@@ -405,11 +414,8 @@ const ChatPage: React.FC = () => {
       </div> {/* <- fecha o scroller */}
 
       {/* BARRA DE INPUT */}
-      <div
-        ref={inputBarRef}
-        className="sticky bottom-0 z-40 px-3 sm:px-6 pb-2 pt-2 glass border-t-0"
-      >
-        <div className="w-full mx-auto max-w-[720px]">
+      <div ref={inputBarRef} className="sticky bottom-0 z-40 bg-gradient-to-t from-white via-white/95 to-white/80 px-4 pb-3 pt-3 sm:px-6 lg:px-10">
+        <div className="w-full mx-auto max-w-3xl">
           <QuickSuggestions
             visible={showQuick && messages.length === 0 && !digitando && !erroApi}
             onPickSuggestion={handlePickSuggestion}

--- a/src/pages/MemoryPage.tsx
+++ b/src/pages/MemoryPage.tsx
@@ -87,117 +87,122 @@ const MemoryPage: React.FC = () => {
   } = useMemoryPageData(userId);
 
   return (
-    <PhoneFrame className="flex flex-col h-full bg-white">
-      <div className="sticky top-0 z-10 px-4 pt-4 pb-3 bg-white/70 backdrop-blur-md border-b border-black/10">
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => navigate('/chat')}
-            className="inline-flex items-center justify-center h-9 w-9 rounded-full border border-black/10 bg-white/70 backdrop-blur hover:bg-white transition"
-            aria-label="Voltar"
-          >
-            <ArrowLeft size={20} className="text-neutral-700" />
-          </button>
+    <PhoneFrame className="flex h-full flex-col bg-white">
+      <div className="sticky top-0 z-10 border-b border-black/5 bg-white/80 px-4 pb-3 pt-4 backdrop-blur-xl sm:px-6">
+        <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-3">
+          <div className="flex w-full items-center justify-between gap-3">
+            <button
+              onClick={() => navigate('/chat')}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-black/10 bg-white/80 backdrop-blur hover:bg-white transition"
+              aria-label="Voltar"
+            >
+              <ArrowLeft size={20} className="text-neutral-700" />
+            </button>
 
-          <div className="glass-panel rounded-full p-1 flex gap-1">
-            {(['memories', 'profile', 'report'] as const).map((t) => {
-              const active = activeTab === t;
-              return (
-                <button
-                  key={t}
-                  onClick={() => goTab(t)}
-                  aria-pressed={active}
-                  className={[
-                    'px-3 py-1.5 rounded-full text-[13px] font-medium transition',
-                    active
-                      ? 'bg-white text-neutral-900 shadow-sm border border-white/60'
-                      : 'text-neutral-700 hover:bg-white/40',
-                  ].join(' ')}
-                >
-                  {{ memories: 'Memórias', profile: 'Perfil Emocional', report: 'Relatório' }[t]}
-                </button>
-              );
-            })}
+            <div className="glass-panel flex items-center gap-1 rounded-full p-1">
+              {(['memories', 'profile', 'report'] as const).map((t) => {
+                const active = activeTab === t;
+                return (
+                  <button
+                    key={t}
+                    onClick={() => goTab(t)}
+                    aria-pressed={active}
+                    className={[
+                      'px-3 py-1.5 text-[13px] font-medium transition rounded-full',
+                      active
+                        ? 'bg-white text-neutral-900 shadow-sm ring-1 ring-white/60'
+                        : 'text-neutral-700 hover:bg-white/40',
+                    ].join(' ')}
+                  >
+                    {{ memories: 'Memórias', profile: 'Perfil Emocional', report: 'Relatório' }[t]}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="hidden h-9 w-9 sm:block" aria-hidden />
           </div>
-        </div>
 
-        <div className="mt-2 text-center">
-          <h1 className="text-[22px] font-semibold text-neutral-900 tracking-tight">
-            {{
-              memories: 'Minhas Memórias',
-              profile: 'Meu Perfil Emocional',
-              report: 'Relatório Emocional',
-            }[activeTab]}
-          </h1>
-          <p className="text-sm text-neutral-500 mt-1">
-            {{
-              memories: 'Registre e relembre seus sentimentos',
-              profile: 'Seu panorama emocional em destaque',
-              report: 'Análise aprofundada das suas memórias',
-            }[activeTab]}
-          </p>
+          <div className="text-center">
+            <h1 className="text-[22px] font-semibold tracking-tight text-neutral-900">
+              {{
+                memories: 'Minhas Memórias',
+                profile: 'Meu Perfil Emocional',
+                report: 'Relatório Emocional',
+              }[activeTab]}
+            </h1>
+            <p className="mt-1 text-sm text-neutral-500">
+              {{
+                memories: 'Registre e relembre seus sentimentos',
+                profile: 'Seu panorama emocional em destaque',
+                report: 'Análise aprofundada das suas memórias',
+              }[activeTab]}
+            </p>
+          </div>
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 pb-6">
-        {loading ? (
-          <div className="flex justify-center items-center h-full text-neutral-500 text-sm">Carregando…</div>
-        ) : error ? (
-          <div className="flex justify-center items-center h-full text-rose-500 text-sm">{error}</div>
-        ) : (
-          <>
-            {activeTab === 'memories' && (
-              <>
-                <div className="glass-panel p-3 rounded-2xl mb-3">
-                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-                    <select
-                      value={emoFilter}
-                      onChange={(event) => setEmoFilter(event.target.value)}
-                      className="h-10 rounded-xl px-3 bg-white/80 border border-black/10 text-sm"
-                    >
-                      <option value="all">Todas as emoções</option>
-                      {emotionOptions.map((emo) => (
-                        <option key={emo} value={emo}>
-                          {emo[0].toUpperCase() + emo.slice(1)}
-                        </option>
-                      ))}
-                    </select>
+      <div className="flex-1 overflow-y-auto px-4 pb-6 sm:px-6">
+        <div className="mx-auto flex h-full w-full max-w-4xl flex-col">
+          {loading ? (
+            <div className="flex flex-1 items-center justify-center text-sm text-neutral-500">Carregando…</div>
+          ) : error ? (
+            <div className="flex flex-1 items-center justify-center text-sm text-rose-500">{error}</div>
+          ) : (
+            <div className="flex-1 space-y-6 pb-4">
+              {activeTab === 'memories' && (
+                <>
+                  <div className="glass-panel mb-3 rounded-2xl p-3 sm:p-4">
+                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-3">
+                      <select
+                        value={emoFilter}
+                        onChange={(event) => setEmoFilter(event.target.value)}
+                        className="h-11 rounded-xl border border-black/10 bg-white/80 px-3 text-sm"
+                      >
+                        <option value="all">Todas as emoções</option>
+                        {emotionOptions.map((emo) => (
+                          <option key={emo} value={emo}>
+                            {emo[0].toUpperCase() + emo.slice(1)}
+                          </option>
+                        ))}
+                      </select>
 
-                    <input
-                      type="text"
-                      value={query}
-                      onChange={(event) => setQuery(event.target.value)}
-                      placeholder="Buscar em tags, reflexão ou pensamento…"
-                      className="h-10 rounded-xl px-3 bg-white/80 border border-black/10 text-sm"
-                    />
-
-                    <div className="flex items-center gap-3">
-                      <label className="text-xs text-neutral-600 w-24">Intensidade ≥ {minIntensity}</label>
                       <input
-                        type="range"
-                        min={0}
-                        max={10}
-                        step={1}
-                        value={minIntensity}
-                        onChange={(event) => setMinIntensity(Number(event.target.value))}
-                        className="flex-1"
+                        type="text"
+                        value={query}
+                        onChange={(event) => setQuery(event.target.value)}
+                        placeholder="Buscar em tags, reflexão ou pensamento…"
+                        className="h-11 rounded-xl border border-black/10 bg-white/80 px-3 text-sm"
                       />
+
+                      <div className="flex items-center gap-3 rounded-xl border border-black/5 bg-white/60 px-3 py-1.5">
+                        <label className="w-24 text-xs text-neutral-600">Intensidade ≥ {minIntensity}</label>
+                        <input
+                          type="range"
+                          min={0}
+                          max={10}
+                          step={1}
+                          value={minIntensity}
+                          onChange={(event) => setMinIntensity(Number(event.target.value))}
+                          className="flex-1"
+                        />
+                      </div>
                     </div>
+
+                    {filtersActive && (
+                      <div className="mt-3 flex justify-end">
+                        <button
+                          onClick={resetFilters}
+                          className="rounded-full border border-black/10 bg-white/80 px-3 py-1 text-xs transition hover:bg-white"
+                        >
+                          Limpar filtros
+                        </button>
+                      </div>
+                    )}
                   </div>
 
-                  {filtersActive && (
-                    <div className="mt-2 flex justify-end">
-                      <button
-                        onClick={resetFilters}
-                        className="text-xs px-3 py-1 rounded-full border border-black/10 bg-white/70 hover:bg-white transition"
-                      >
-                        Limpar filtros
-                      </button>
-                    </div>
-                  )}
-                </div>
-
-                {filteredMemories.length > 0 ? (
-                  <div className="space-y-6">
+                  {filteredMemories.length > 0 ? (
+                    <div className="space-y-6">
                     {groupOrder
                       .filter((bucket) => groupedMemories[bucket]?.length)
                       .map((bucket) => (


### PR DESCRIPTION
## Summary
- apply SF Pro typography and glassmorphism refinements to chat bubbles, typing indicator, and input controls for an Apple-inspired feel
- refresh the chat page background, spacing, and Eco presence icon while keeping the experience responsive across viewports
- center the memory, profile, and report tabs with updated filter cards for a cohesive layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d703e74b108325954c06aee49adf96