### PR TITLE
Add reset password route and page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { ChatProvider } from './contexts/ChatContext';
 
 import LoginPage from './pages/LoginPage';
+import ResetSenha from './pages/ResetSenha';
 import ChatPage from './pages/ChatPage';
 import VoicePage from './pages/VoicePage';
 import CreateProfilePage from './pages/CreateProfilePage';
@@ -39,6 +40,7 @@ function AppInner() {
         <Route path="/login/tour" element={<LoginPage />} />
 
         <Route path="/register" element={<CreateProfilePage />} />
+        <Route path="/reset-senha" element={<ResetSenha />} />
 
         <Route
           path="/chat"

--- a/src/pages/ResetSenha.tsx
+++ b/src/pages/ResetSenha.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function ResetSenha() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-white px-4 py-12">
+      <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-8 text-center shadow-sm">
+        <h1 className="text-2xl font-semibold text-gray-900">Redefinir senha</h1>
+        <p className="mt-4 text-sm text-gray-600">
+          Este link de redefinição de senha é inválido ou já foi utilizado. Solicite um novo link e tente
+          novamente.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated ResetSenha page to handle password reset redirect traffic
- register the /reset-senha public route so email links work in all environments

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da753b22788325a920a79bdebf9891