### PR TITLE
feat: redesign reset password screen

### DIFF
--- a/src/pages/ResetSenha.tsx
+++ b/src/pages/ResetSenha.tsx
@@ -1,15 +1,191 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-export default function ResetSenha() {
+import { supabase } from '@/lib/supabase';
+
+const ResetSenha: React.FC = () => {
+  const navigate = useNavigate();
+
+  const [novaSenha, setNovaSenha] = useState('');
+  const [confirmarSenha, setConfirmarSenha] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [sessionReady, setSessionReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    const validateRecoverySession = async () => {
+      const { data, error: sessionError } = await supabase.auth.getSession();
+
+      if (!active) return;
+
+      if (sessionError) {
+        setError('Não foi possível validar o link de recuperação. Tente novamente.');
+        setSessionReady(false);
+        return;
+      }
+
+      if (!data.session || !data.session.user) {
+        setError('Este link de redefinição é inválido ou expirou. Solicite um novo link.');
+        setSessionReady(false);
+        return;
+      }
+
+      setSessionReady(true);
+    };
+
+    validateRecoverySession();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const canSubmit = useMemo(() => {
+    return (
+      sessionReady &&
+      !success &&
+      !loading &&
+      novaSenha.trim().length >= 8 &&
+      confirmarSenha.trim().length >= 8 &&
+      novaSenha === confirmarSenha
+    );
+  }, [sessionReady, success, loading, novaSenha, confirmarSenha]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!sessionReady || loading) return;
+
+    const trimmedPassword = novaSenha.trim();
+    const trimmedConfirmation = confirmarSenha.trim();
+
+    if (trimmedPassword.length < 8) {
+      setError('A senha deve ter pelo menos 8 caracteres.');
+      setSuccess('');
+      return;
+    }
+
+    if (trimmedPassword !== trimmedConfirmation) {
+      setError('As senhas devem ser iguais.');
+      setSuccess('');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    const { error: updateError } = await supabase.auth.updateUser({
+      password: trimmedPassword,
+    });
+
+    if (updateError) {
+      setError(updateError.message || 'Não foi possível atualizar a senha.');
+      setLoading(false);
+      return;
+    }
+
+    setSuccess('Senha atualizada!');
+    setLoading(false);
+    setNovaSenha('');
+    setConfirmarSenha('');
+  };
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-white px-4 py-12">
-      <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-8 text-center shadow-sm">
-        <h1 className="text-2xl font-semibold text-gray-900">Redefinir senha</h1>
-        <p className="mt-4 text-sm text-gray-600">
-          Este link de redefinição de senha é inválido ou já foi utilizado. Solicite um novo link e tente
-          novamente.
-        </p>
+    <div className="relative flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 px-4 py-12">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -left-20 top-20 h-72 w-72 rounded-full bg-emerald-400/30 blur-3xl" aria-hidden />
+        <div className="absolute bottom-0 right-0 h-96 w-96 rounded-full bg-cyan-400/20 blur-3xl" aria-hidden />
+      </div>
+
+      <div
+        className="relative w-full max-w-md space-y-6 rounded-3xl border border-white/25 bg-white/10 p-10 text-white shadow-[0_25px_70px_rgba(15,23,42,0.45)] backdrop-blur-2xl"
+      >
+        <header className="space-y-3 text-center">
+          <h1 className="text-3xl font-semibold tracking-tight">Redefinir senha</h1>
+          <p className="text-sm text-slate-200/80">
+            Crie uma nova senha para acessar sua conta com segurança.
+          </p>
+        </header>
+
+        <div aria-live="assertive" className="sr-only">
+          {error}
+        </div>
+        <div aria-live="polite" className="sr-only">
+          {success}
+        </div>
+
+        {error && (
+          <p role="alert" className="rounded-lg border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-sm text-rose-100">
+            {error}
+          </p>
+        )}
+
+        {success && (
+          <p role="status" className="rounded-lg border border-emerald-400/40 bg-emerald-400/10 px-4 py-2 text-sm text-emerald-100">
+            {success}
+          </p>
+        )}
+
+        <form className="space-y-5" onSubmit={handleSubmit} noValidate>
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-slate-100" htmlFor="nova-senha">
+              Nova senha
+            </label>
+            <input
+              id="nova-senha"
+              type="password"
+              autoComplete="new-password"
+              value={novaSenha}
+              onChange={(event) => setNovaSenha(event.target.value)}
+              minLength={8}
+              disabled={!sessionReady || loading || Boolean(success)}
+              className="w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-base text-white placeholder:text-slate-300/70 shadow-inner focus:border-emerald-300 focus:outline-none focus:ring-2 focus:ring-emerald-300/50"
+              placeholder="Digite a nova senha"
+              required
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-slate-100" htmlFor="confirmar-senha">
+              Confirmar senha
+            </label>
+            <input
+              id="confirmar-senha"
+              type="password"
+              autoComplete="new-password"
+              value={confirmarSenha}
+              onChange={(event) => setConfirmarSenha(event.target.value)}
+              minLength={8}
+              disabled={!sessionReady || loading || Boolean(success)}
+              className="w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-base text-white placeholder:text-slate-300/70 shadow-inner focus:border-emerald-300 focus:outline-none focus:ring-2 focus:ring-emerald-300/50"
+              placeholder="Confirme a nova senha"
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="w-full rounded-2xl bg-emerald-400/90 px-4 py-3 text-sm font-semibold uppercase tracking-wider text-slate-900 transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-300/50 disabled:text-slate-500"
+          >
+            {loading ? 'Atualizando...' : 'Atualizar senha'}
+          </button>
+        </form>
+
+        <button
+          type="button"
+          onClick={() => navigate('/login')}
+          className="w-full rounded-2xl border border-white/20 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/10"
+        >
+          Voltar para login
+        </button>
       </div>
     </div>
   );
-}
+};
+
+export default ResetSenha;
+


### PR DESCRIPTION
## Summary
- replace the reset password page with a glassmorphism-inspired card tied to the Supabase recovery session
- validate the new password inputs, calling `supabase.auth.updateUser` and surfacing accessible success and error messaging
- disable submission while processing and provide a direct navigation option back to login

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da77b441b883258a51479768491550