### PR TITLE
refactor: rename supabase client module

### DIFF
--- a/docs/client-request-flow.md
+++ b/docs/client-request-flow.md
@@ -5,7 +5,7 @@ This document describes how a chat message travels through the Eco frontend once
 ## High-level steps
 
 1. **User input captured in the chat UI.** `ChatPage` validates and stages the message, displaying it immediately in the conversation so the interface feels responsive.【F:src/pages/ChatPage.tsx†L203-L276】
-2. **Message is persisted in Supabase.** We call `salvarMensagem`, which inserts the payload into the `mensagem` table through the shared Supabase client, guaranteeing the conversation history is stored before any external calls happen.【F:src/pages/ChatPage.tsx†L218-L224】【F:src/api/mensagem.ts†L4-L27】【F:src/lib/supabaseClient.ts†L1-L6】
+2. **Message is persisted in Supabase.** We call `salvarMensagem`, which inserts the payload into the `mensagem` table through the shared Supabase client, guaranteeing the conversation history is stored before any external calls happen.【F:src/pages/ChatPage.tsx†L218-L224】【F:src/api/mensagem.ts†L4-L27】【F:src/lib/supabase.ts†L1-L6】
 3. **Contextual memories are fetched.** In parallel we ask two memory endpoints (`/memorias/similares_v2` with fallback and `/memorias` filtered by tags) to recover relevant memories that will accompany the prompt. Both helpers reuse the shared Axios instance so that authentication headers and error handling stay consistent.【F:src/pages/ChatPage.tsx†L224-L268】【F:src/api/memoriaApi.ts†L204-L319】
 4. **Supabase session token is attached automatically.** Every request made through `api` pulls the current Supabase session and injects its bearer token, enabling backend Row Level Security (RLS) without forcing each caller to repeat that logic.【F:src/api/axios.ts†L1-L25】
 5. **Prompt is delivered to the Eco backend.** Once the prompt has been assembled with system hints, contextual memories, and the last user turns, `enviarMensagemParaEco` posts it to `/ask-eco`. The helper normalises payloads, validates responses, and surfaces backend errors in a user-friendly way.【F:src/pages/ChatPage.tsx†L261-L292】【F:src/api/ecoApi.ts†L15-L60】
@@ -33,7 +33,7 @@ sequenceDiagram
 
 ## Authentication touchpoints
 
-- Supabase credentials (`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`) initialise the singleton client used for both direct Supabase CRUD operations and session retrieval.【F:src/lib/supabaseClient.ts†L1-L6】
+- Supabase credentials (`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`) initialise the singleton client used for both direct Supabase CRUD operations and session retrieval.【F:src/lib/supabase.ts†L1-L6】
 - The Axios instance (`api`) centralises the API base URL, credentials policy, and Supabase bearer injection. Any new client-side request should reuse this instance to inherit the existing authentication behaviour.【F:src/api/axios.ts†L5-L25】
 
 ## Error handling strategy

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,6 @@
 // src/api/axios.ts
 import axios from "axios";
-import { supabase } from "../lib/supabaseClient"; // ajuste o path se preciso
+import { supabase } from "../lib/supabase"; // ajuste o path se preciso
 
 const API_BASE =
   import.meta.env.VITE_API_BASE?.replace(/\/+$/, "") ||

--- a/src/api/mensagem.ts
+++ b/src/api/mensagem.ts
@@ -1,5 +1,5 @@
 // src/api/mensagem.ts
-import { supabase } from '../lib/supabaseClient'
+import { supabase } from '../lib/supabase'
 
 export async function salvarMensagem({
   usuarioId,

--- a/src/api/usuario.ts
+++ b/src/api/usuario.ts
@@ -1,5 +1,5 @@
 // src/api/usuario.ts
-import { supabase } from '../lib/supabaseClient'
+import { supabase } from '../lib/supabase'
 
 export async function criarUsuario({
   nome,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 // src/contexts/AuthContext.tsx
 import { createContext, useContext, useEffect, useState } from 'react';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '../lib/supabase';
 import type { Session, User, AuthChangeEvent } from '@supabase/supabase-js';
 
 interface AuthContextType {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,1 +1,6 @@
-export { supabase } from './supabaseClient';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,0 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/pages/VoicePage.tsx
+++ b/src/pages/VoicePage.tsx
@@ -4,7 +4,7 @@ import { Mic, StopCircle, Loader, BookOpen, X } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { sendVoiceMessage } from "../api/voiceApi";
 import { useAuth } from "../contexts/AuthContext";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "../lib/supabase";
 
 /** Mude para false quando quiser liberar a gravação */
 const UNDER_CONSTRUCTION = true;


### PR DESCRIPTION
## Summary
- rename the Supabase client module to `supabase.ts` and remove the old wrapper
- update all imports and documentation references to the new module name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7976bf68832594854f7716f151c8