### PR TITLE
Fix password reset redirect base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Base URL used for Supabase auth redirect callbacks.
+# Uncomment the appropriate value for your environment before running the app.
+VITE_APP_URL=https://your-production-domain.com
+# VITE_APP_URL=http://localhost:5173
+
+# Supabase project settings
+VITE_SUPABASE_URL=https://your-supabase-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Optional integrations
+VITE_API_URL=https://your-backend.example.com/api
+VITE_ELEVENLABS_VOICE_ID=your-elevenlabs-voice-id
+VITE_MIXPANEL_TOKEN=your-mixpanel-token
+VITE_FB_PIXEL_ID=your-facebook-pixel-id

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -133,10 +133,17 @@ const LoginPage: React.FC = () => {
     setForgotLoading(true);
 
     try {
+      const envAppUrl = import.meta.env.VITE_APP_URL;
+      const fallbackOrigin =
+        typeof window !== 'undefined' && window.location?.origin
+          ? window.location.origin
+          : '';
+      const baseUrl = (envAppUrl || fallbackOrigin).replace(/\/+$/, '');
+
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(
         trimmedEmail,
         {
-          redirectTo: `${import.meta.env.VITE_APP_URL}/reset-senha`,
+          redirectTo: `${baseUrl}/reset-senha`,
         },
       );
 


### PR DESCRIPTION
## Summary
- derive the password reset redirect link from the configured app URL with a window origin fallback
- provide a `.env.example` that documents the required VITE_APP_URL and other environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7ff8cca8832583b7108158031965