### PR TITLE
Add Google OAuth login path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,17 @@ function AppInner() {
         <Route path="/reset-senha" element={<ResetSenha />} />
 
         <Route
+          path="/app"
+          element={
+            <ProtectedRoute>
+              <MainLayout>
+                <ChatPage />
+              </MainLayout>
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
           path="/chat"
           element={
             <ProtectedRoute>

--- a/src/lib/ensureProfile.ts
+++ b/src/lib/ensureProfile.ts
@@ -1,0 +1,51 @@
+import type { User } from '@supabase/supabase-js';
+import { supabase } from './supabaseClient';
+
+/**
+ * Garante que exista um registro correspondente ao usuário autenticado
+ * na tabela `usuarios`, evitando acessos a perfis de terceiros.
+ */
+export async function ensureProfile(user: User | null | undefined) {
+  if (!user?.id) return;
+
+  const userId = user.id;
+
+  // Verifica se o perfil já existe (restrito ao próprio usuário pela cláusula eq)
+  const { data: existingProfile, error: fetchError } = await supabase
+    .from('usuarios')
+    .select('id')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (fetchError) {
+    // Ignora erro "not found" (PostgREST code PGRST116) e prossegue para criação
+    if ((fetchError as any)?.code !== 'PGRST116') {
+      throw fetchError;
+    }
+  }
+
+  if (existingProfile) return;
+
+  const fullName =
+    (user.user_metadata?.full_name as string | undefined) ||
+    (user.user_metadata?.name as string | undefined) ||
+    user.email?.split('@')[0] ||
+    'Sem nome';
+
+  const profilePayload = {
+    id: userId,
+    email: user.email,
+    nome: fullName,
+    telefone: (user.user_metadata?.phone as string | undefined) ?? null,
+    data_criacao: new Date().toISOString(),
+    tipo_plano: (user.user_metadata?.plan as string | undefined) ?? 'free',
+    ativo: true,
+  };
+
+  const { error: insertError } = await supabase.from('usuarios').insert([profilePayload]);
+
+  if (insertError && (insertError as any)?.code !== '23505') {
+    // 23505 = unique_violation (perfil já criado por trigger simultânea)
+    throw insertError;
+  }
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -54,7 +54,7 @@ function translateAuthError(err: any): string {
 }
 
 const LoginPage: React.FC = () => {
-  const { signIn, user } = useAuth();
+  const { signIn, signInWithGoogle, user } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -73,7 +73,8 @@ const LoginPage: React.FC = () => {
   const canSubmit = email.trim().length > 3 && password.length >= 6 && !loading;
 
   useEffect(() => {
-    if (user) navigate('/chat');
+    if (!user) return;
+    navigate('/app');
   }, [user, navigate]);
 
   useEffect(() => {
@@ -117,6 +118,17 @@ const LoginPage: React.FC = () => {
       setError(translateAuthError(err));
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleGoogleLogin = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      await signInWithGoogle();
+    } catch (err: any) {
+      setLoading(false);
+      setError(translateAuthError(err));
     }
   };
 
@@ -267,6 +279,22 @@ const LoginPage: React.FC = () => {
 
             {/* Actions */}
             <div className="pt-1 space-y-4">
+              <button
+                type="button"
+                onClick={handleGoogleLogin}
+                disabled={loading}
+                className={[
+                  'w-full h-11 rounded-2xl font-semibold',
+                  'bg-white/70 backdrop-blur-xl',
+                  'border border-white/80 ring-1 ring-slate-900/5',
+                  'text-slate-900 shadow-[0_10px_28px_rgba(2,6,23,0.10)]',
+                  'hover:bg-white/80 active:translate-y-[0.5px]',
+                  'focus:outline-none focus:ring-2 focus:ring-slate-700/10',
+                ].join(' ')}
+              >
+                Continuar com Google
+              </button>
+
               <button
                 type="submit"
                 disabled={!canSubmit}


### PR DESCRIPTION
## Summary
- add a Google sign-in CTA to the login flow and redirect authenticated users to /app
- expose a Supabase signInWithGoogle helper that ensures the usuario profile exists after OAuth callbacks
- register an /app protected route and share the ensureProfile utility for future reuse

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da8afa7f28832591d4bd695cd58e8c