### PR TITLE
Refine memory page loading flow

### DIFF
--- a/src/pages/memory/MemoriesSection.tsx
+++ b/src/pages/memory/MemoriesSection.tsx
@@ -12,7 +12,7 @@ import { getCreatedAt, getEmotion, Memoria } from './utils';
 const BUCKET_ORDER = ['Hoje', 'Ontem', 'Esta semana', 'Este mês', 'Anteriores'] as const;
 
 const MemoriesSection: React.FC = () => {
-  const { memories, loading, error } = useMemoryData();
+  const { memories, memoriesLoading, memoriesError } = useMemoryData();
 
   const {
     emotionOptions,
@@ -25,7 +25,7 @@ const MemoriesSection: React.FC = () => {
     resetFilters,
   } = useMemoriesFilters(memories as Memoria[]);
 
-  if (loading) {
+  if (memoriesLoading) {
     return (
       <div className="flex items-center justify-center h-64">
         <EcoBubbleLoading size={120} text="Carregando memórias..." breathingSec={2} />
@@ -33,10 +33,10 @@ const MemoriesSection: React.FC = () => {
     );
   }
 
-  if (error) {
+  if (memoriesError) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-red-500 text-[15px]">{error}</div>
+        <div className="text-red-500 text-[15px]">{memoriesError}</div>
       </div>
     );
   }

--- a/src/pages/memory/MemoryLayout.tsx
+++ b/src/pages/memory/MemoryLayout.tsx
@@ -15,8 +15,12 @@ const MemoryLayout: React.FC = () => {
     memories: [],
     perfil: null,
     relatorio: null,
-    loading: true,
-    error: null,
+    memoriesLoading: true,
+    perfilLoading: true,
+    relatorioLoading: true,
+    memoriesError: null,
+    perfilError: null,
+    relatorioError: null,
   });
 
   useEffect(() => {
@@ -24,45 +28,100 @@ const MemoryLayout: React.FC = () => {
 
     const load = async () => {
       if (!userId) {
-        setState((s) => ({ ...s, loading: true, error: null }));
-        return;
-      }
-
-      setState((s) => ({ ...s, loading: true, error: null }));
-
-      const results = await Promise.allSettled([
-        buscarMemoriasPorUsuario(userId),
-        buscarPerfilEmocional(userId),
-        buscarRelatorioEmocional(userId),
-      ]);
-
-      if (!alive) return;
-
-      const [memsRes, perfilRes, relRes] = results;
-
-      const memories =
-        memsRes.status === 'fulfilled'
-          ? memsRes.value.filter(
-              (m: any) => m?.salvar_memoria === true || m?.salvar_memoria === 'true'
-            )
-          : [];
-
-      const perfil = perfilRes.status === 'fulfilled' ? perfilRes.value : null;
-      const relatorio = relRes.status === 'fulfilled' ? relRes.value : null;
-
-      const allFailed = results.every((r) => r.status === 'rejected');
-
-      if (allFailed) {
         setState({
           memories: [],
           perfil: null,
           relatorio: null,
-          loading: false,
-          error: 'Erro ao carregar dados.',
+          memoriesLoading: true,
+          perfilLoading: true,
+          relatorioLoading: true,
+          memoriesError: null,
+          perfilError: null,
+          relatorioError: null,
         });
-      } else {
-        setState({ memories, perfil, relatorio, loading: false, error: null });
+        return;
       }
+
+      setState({
+        memories: [],
+        perfil: null,
+        relatorio: null,
+        memoriesLoading: true,
+        perfilLoading: true,
+        relatorioLoading: true,
+        memoriesError: null,
+        perfilError: null,
+        relatorioError: null,
+      });
+
+      const fetchMemories = async () => {
+        try {
+          const response = await buscarMemoriasPorUsuario(userId);
+          if (!alive) return;
+
+          const filtered = response.filter(
+            (m: any) => m?.salvar_memoria === true || m?.salvar_memoria === 'true'
+          );
+
+          setState((s) => ({
+            ...s,
+            memories: filtered,
+            memoriesLoading: false,
+          }));
+        } catch (err) {
+          if (!alive) return;
+          setState((s) => ({
+            ...s,
+            memories: [],
+            memoriesLoading: false,
+            memoriesError: 'Não foi possível carregar memórias.',
+          }));
+        }
+      };
+
+      const fetchPerfil = async () => {
+        try {
+          const response = await buscarPerfilEmocional(userId);
+          if (!alive) return;
+          setState((s) => ({
+            ...s,
+            perfil: response,
+            perfilLoading: false,
+          }));
+        } catch (err) {
+          if (!alive) return;
+          setState((s) => ({
+            ...s,
+            perfil: null,
+            perfilLoading: false,
+            perfilError: 'Não foi possível carregar o perfil emocional.',
+          }));
+        }
+      };
+
+      const fetchRelatorio = async () => {
+        try {
+          const response = await buscarRelatorioEmocional(userId);
+          if (!alive) return;
+          setState((s) => ({
+            ...s,
+            relatorio: response,
+            relatorioLoading: false,
+          }));
+        } catch (err) {
+          if (!alive) return;
+          setState((s) => ({
+            ...s,
+            relatorio: null,
+            relatorioLoading: false,
+            relatorioError: 'Não foi possível carregar o relatório emocional.',
+          }));
+        }
+      };
+
+      void fetchMemories();
+      void fetchPerfil();
+      void fetchRelatorio();
     };
 
     load();
@@ -77,13 +136,24 @@ const MemoryLayout: React.FC = () => {
           Mantemos a estrutura simples pra evitar “topo duplicado” em webviews */}
       <PhoneFrame className="flex flex-col h-full bg-white">
         <div className="flex-1 overflow-y-auto px-4 py-4 relative">
-          {state.error && (
-            <div className="mb-3 text-center text-xs text-rose-600">
-              {state.error}
-            </div>
-          )}
+          {(() => {
+            const messages = [
+              state.memoriesError,
+              state.perfilError,
+              state.relatorioError,
+            ].filter(Boolean) as string[];
+            const uniqueMessages = Array.from(new Set(messages));
+            if (!uniqueMessages.length) return null;
+            return (
+              <div className="mb-3 space-y-1 text-center text-xs text-rose-600">
+                {uniqueMessages.map((message, index) => (
+                  <div key={`${message}-${index}`}>{message}</div>
+                ))}
+              </div>
+            );
+          })()}
 
-          {state.loading ? (
+          {state.memoriesLoading && state.perfilLoading && state.relatorioLoading ? (
             <div className="h-[calc(100%-0px)] min-h-[320px] flex items-center justify-center">
               <EcoBubbleLoading size={120} text="Carregando dados..." />
             </div>

--- a/src/pages/memory/ProfileSection.tsx
+++ b/src/pages/memory/ProfileSection.tsx
@@ -147,7 +147,14 @@ const SegmentedControl: FC<{ value: Period; onChange: (p: Period)=>void }> = ({ 
 
 /* ---------- componente ---------- */
 const ProfileSection: FC = () => {
-  const { perfil, memories, loading, error } = useMemoryData();
+  const {
+    perfil,
+    memories,
+    perfilLoading,
+    memoriesLoading,
+    perfilError,
+    memoriesError,
+  } = useMemoryData();
   const [memLocal, setMemLocal] = useState<Memoria[] | null>(null);
   const [fetchingLocal, setFetchingLocal] = useState(false);
   const [period, setPeriod] = useState<Period>(7);
@@ -229,14 +236,22 @@ const ProfileSection: FC = () => {
       )}
 
       <div className="mx-auto w-full max-w-[980px] px-4 md:px-6 py-6 md:py-8 space-y-8 md:space-y-10">
-        {(loading || fetchingLocal) && (
+        {(perfilLoading || memoriesLoading || fetchingLocal) && (
           <div className="rounded-2xl border border-neutral-200 bg-white px-4 py-10 grid place-items-center">
             <EcoBubbleLoading size={72} text="Carregando…" />
           </div>
         )}
-        {error && (
-          <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-rose-700 text-sm">{error}</div>
-        )}
+        {(() => {
+          const messages = [perfilError, memoriesError].filter(Boolean) as string[];
+          if (!messages.length) return null;
+          return (
+            <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-rose-700 text-sm space-y-1">
+              {messages.map((message, index) => (
+                <div key={`${message}-${index}`}>{message}</div>
+              ))}
+            </div>
+          );
+        })()}
 
         {/* CARD 1 — Resumo */}
         <Card title="Resumo" id="resumo">

--- a/src/pages/memory/ReportSection.tsx
+++ b/src/pages/memory/ReportSection.tsx
@@ -117,7 +117,7 @@ const QuadrantLegend = () => (
 /* ---------- Main ---------- */
 
 const ReportSection: React.FC = () => {
-  const { relatorio, loading, error } = useMemoryData();
+  const { relatorio, relatorioLoading, relatorioError } = useMemoryData();
   const [heatmapRange, setHeatmapRange] = useState<30 | 90 | 180 | undefined>(30);
 
   const mapaEmocional2D = useMemo(() => {
@@ -143,7 +143,7 @@ const ReportSection: React.FC = () => {
       );
   }, [relatorio]);
 
-  if (loading) {
+  if (relatorioLoading) {
     return (
       <section className="space-y-4 max-h-[82vh] overflow-y-auto pr-1">
         <div className="sticky top-0 z-20 -mx-1 px-1 py-2 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70 border-b border-neutral-100">
@@ -169,10 +169,10 @@ const ReportSection: React.FC = () => {
     );
   }
 
-  if (error) {
+  if (relatorioError) {
     return (
       <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-rose-700 text-sm">
-        {error}
+        {relatorioError}
       </div>
     );
   }

--- a/src/pages/memory/memoryData.ts
+++ b/src/pages/memory/memoryData.ts
@@ -6,16 +6,24 @@ export type MemoryData = {
   memories: Memoria[];
   perfil: any | null;
   relatorio: RelatorioEmocional | null;
-  loading: boolean;
-  error: string | null;
+  memoriesLoading: boolean;
+  perfilLoading: boolean;
+  relatorioLoading: boolean;
+  memoriesError: string | null;
+  perfilError: string | null;
+  relatorioError: string | null;
 };
 
 const defaultValue: MemoryData = {
   memories: [],
   perfil: null,
   relatorio: null,
-  loading: true,
-  error: null,
+  memoriesLoading: true,
+  perfilLoading: true,
+  relatorioLoading: true,
+  memoriesError: null,
+  perfilError: null,
+  relatorioError: null,
 };
 
 export const MemoryDataContext = createContext<MemoryData>(defaultValue);


### PR DESCRIPTION
## Summary
- expose per-resource loading and error flags from the memory data context
- update MemoryLayout to fetch each resource independently and surface individual errors
- adjust memory, profile, and report sections to rely on the new flags for loaders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da911154c4832598aef65be6c89778