### PR TITLE
Lazy load memory routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // src/App.tsx
-import React, { useEffect } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { ChatProvider } from './contexts/ChatContext';
@@ -12,12 +12,19 @@ import CreateProfilePage from './pages/CreateProfilePage';
 import ProtectedRoute from './components/ProtectedRoute';
 import mixpanel from './lib/mixpanel';
 import MainLayout from './layouts/MainLayout';
+import EcoBubbleLoading from './components/EcoBubbleLoading';
 
 // MEMÓRIAS
-import MemoryLayout from './pages/memory/MemoryLayout';
-import MemoriesSection from './pages/memory/MemoriesSection';
-import ProfileSection from './pages/memory/ProfileSection';
-import ReportSection from './pages/memory/ReportSection';
+const MemoryLayout = React.lazy(() => import('./pages/memory/MemoryLayout'));
+const MemoriesSection = React.lazy(() => import('./pages/memory/MemoriesSection'));
+const ProfileSection = React.lazy(() => import('./pages/memory/ProfileSection'));
+const ReportSection = React.lazy(() => import('./pages/memory/ReportSection'));
+
+const memorySuspenseFallback = (
+  <div className="flex min-h-[320px] items-center justify-center py-10">
+    <EcoBubbleLoading size={120} text="Carregando memórias..." />
+  </div>
+);
 
 /** Wrapper para dar key por usuário ao ChatProvider */
 function ChatProviderWithKey({ children }: { children: React.ReactNode }) {
@@ -81,14 +88,37 @@ function AppInner() {
           element={
             <ProtectedRoute>
               <MainLayout>
-                <MemoryLayout />
+                <Suspense fallback={memorySuspenseFallback}>
+                  <MemoryLayout />
+                </Suspense>
               </MainLayout>
             </ProtectedRoute>
           }
         >
-          <Route index element={<MemoriesSection />} />
-          <Route path="profile" element={<ProfileSection />} />
-          <Route path="report" element={<ReportSection />} />
+          <Route
+            index
+            element={
+              <Suspense fallback={memorySuspenseFallback}>
+                <MemoriesSection />
+              </Suspense>
+            }
+          />
+          <Route
+            path="profile"
+            element={
+              <Suspense fallback={memorySuspenseFallback}>
+                <ProfileSection />
+              </Suspense>
+            }
+          />
+          <Route
+            path="report"
+            element={
+              <Suspense fallback={memorySuspenseFallback}>
+                <ReportSection />
+              </Suspense>
+            }
+          />
           <Route path="*" element={<Navigate to="/memory" replace />} />
         </Route>
 

--- a/src/pages/memory/MemoryLayout.tsx
+++ b/src/pages/memory/MemoryLayout.tsx
@@ -130,6 +130,11 @@ const MemoryLayout: React.FC = () => {
     };
   }, [userId]);
 
+  useEffect(() => {
+    void import('./ProfileSection');
+    void import('./ReportSection');
+  }, []);
+
   return (
     <MemoryDataContext.Provider value={state}>
       {/* Sem paddings de header/side aqui — o MainLayout já aplica.


### PR DESCRIPTION
## Summary
- switch memory pages in App.tsx to use React.lazy with a shared suspense fallback loader
- wrap all /memory route elements in Suspense so users see EcoBubbleLoading while chunks load
- prefetch profile and report sections after MemoryLayout mounts to improve responsiveness

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da9257d7d483258987c32898d91286