### PR TITLE
Add feedback shortcut to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -124,6 +124,14 @@ const Header: React.FC<HeaderProps> = ({
               <ArrowLeft className="h-5 w-5 text-slate-900" />
             </button>
           )}
+          <a
+            href="https://feedback777.vercel.app"
+            target="_blank"
+            rel="noreferrer"
+            className="px-3 py-1.5 rounded-[14px] bg-black/[0.04] hover:bg-black/[0.06] border border-black/[0.08] text-slate-900 text-sm"
+          >
+            Feedback
+          </a>
           {onLogout && (
             <button
               onClick={onLogout}


### PR DESCRIPTION
## Summary
- add a Feedback button to the header topbar alongside the existing controls
- match the visual styling of other buttons and ensure it opens the external feedback page in a new tab

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68da9a512f8883259c075db8cd0f6595