### PR TITLE
Remove gradient background from chat page

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -316,13 +316,7 @@ const ChatPage: React.FC = () => {
   };
 
   return (
-    <div
-      className="relative flex h-[calc(100dvh-var(--eco-topbar-h,56px))] w-full flex-col overflow-hidden bg-white"
-      style={{
-        backgroundImage:
-          'radial-gradient(140% 100% at 50% 0%, rgba(236,240,255,0.65), transparent 55%), linear-gradient(180deg, #ffffff 0%, #f6f8ff 100%)',
-      }}
-    >
+    <div className="relative flex h-[calc(100dvh-var(--eco-topbar-h,56px))] w-full flex-col overflow-hidden bg-white">
       {/* SCROLLER */}
       <div
         ref={scrollerRef}


### PR DESCRIPTION
## Summary
- remove the gradient background override from the chat page container so it stays pure white

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dab95b11548325878c0c90b6b978b6