### PR TITLE
Add emotion tokenized eye bubbles to memory UI

### DIFF
--- a/src/components/EyeBubbleBase.tsx
+++ b/src/components/EyeBubbleBase.tsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import { motion, MotionProps } from 'framer-motion';
+
+import type { MicroMotionPattern } from '../pages/memory/emotionTokens';
+
+export type MotionConfig = Pick<MotionProps, 'animate' | 'transition'>;
+
+export type MotionFactory<T extends object = {}> = (options: { reduceMotion: boolean } & T) => MotionConfig;
+
+export type EyeBubbleToken = {
+  gradient: [string, string];
+  highlight: [string, string];
+  irisGradient: [string, string];
+  irisHighlight: [string, string];
+  pupilColor: string;
+  irisScale: number;
+  pupilScale: number;
+  eyelidOffset: number;
+  blinkCadence: number;
+  microMotion: MicroMotionPattern;
+  accent?: string;
+  eyelidSurface?: string;
+  animations?: {
+    bubble?: MotionFactory;
+    iris?: MotionFactory;
+    pupil?: MotionFactory;
+    eyelid?: MotionFactory<{ restingScale: number }>;
+  };
+};
+
+const STATIC_MOTION: MotionConfig = { animate: { scale: 1 } };
+const STATIC_PUPIL: MotionConfig = { animate: { scale: 1, x: 0, y: 0, opacity: 1 } };
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const createMicroMotion = (pattern: MicroMotionPattern, reduceMotion: boolean) => {
+  if (reduceMotion) {
+    return { bubble: STATIC_MOTION, iris: STATIC_MOTION, pupil: STATIC_PUPIL } as const;
+  }
+
+  switch (pattern) {
+    case 'pulse':
+      return {
+        bubble: {
+          animate: { scale: [1, 1.07, 1] },
+          transition: { duration: 2.4, repeat: Infinity, ease: 'easeInOut' },
+        },
+        iris: {
+          animate: { scale: [1, 1.05, 1] },
+          transition: { duration: 2.2, repeat: Infinity, ease: 'easeInOut' },
+        },
+        pupil: {
+          animate: { scale: [1, 0.94, 1] },
+          transition: { duration: 2.2, repeat: Infinity, ease: 'easeInOut' },
+        },
+      } as const;
+    case 'breathing':
+      return {
+        bubble: {
+          animate: { scale: [1, 1.04, 1] },
+          transition: { duration: 3.4, repeat: Infinity, ease: 'easeInOut' },
+        },
+        iris: {
+          animate: { scale: [1, 1.03, 1] },
+          transition: { duration: 3.2, repeat: Infinity, ease: 'easeInOut' },
+        },
+        pupil: STATIC_PUPIL,
+      } as const;
+    case 'tremor':
+      return {
+        bubble: {
+          animate: { rotate: [0, 2.2, -1.8, 2.2, 0] },
+          transition: { duration: 1.2, repeat: Infinity, ease: 'easeInOut' },
+        },
+        iris: {
+          animate: { rotate: [0, -1.5, 1.2, -1.2, 0] },
+          transition: { duration: 1.2, repeat: Infinity, ease: 'easeInOut' },
+        },
+        pupil: {
+          animate: { x: [0, -0.8, 0.6, -0.5, 0], y: [0, 0.6, -0.5, 0.4, 0] },
+          transition: { duration: 1.2, repeat: Infinity, ease: 'easeInOut' },
+        },
+      } as const;
+    case 'tracking':
+      return {
+        bubble: {
+          animate: { x: [0, 1.6, -1.2, 1.2, 0], y: [0, -1.4, 1.1, -0.9, 0] },
+          transition: { duration: 3.6, repeat: Infinity, ease: 'easeInOut' },
+        },
+        iris: STATIC_MOTION,
+        pupil: {
+          animate: { x: [0, -1.4, 1.6, -1.2, 0], y: [0, 1.2, -1.4, 1.1, 0] },
+          transition: { duration: 3.6, repeat: Infinity, ease: 'easeInOut' },
+        },
+      } as const;
+    case 'shortOscillation':
+      return {
+        bubble: {
+          animate: { rotate: [-1.6, 1.6, -1.2, 1.2, -1.6] },
+          transition: { duration: 2.2, repeat: Infinity, ease: 'easeInOut' },
+        },
+        iris: {
+          animate: { scale: [1, 0.97, 1.02, 0.98, 1] },
+          transition: { duration: 2.2, repeat: Infinity, ease: 'easeInOut' },
+        },
+        pupil: STATIC_PUPIL,
+      } as const;
+    default:
+      return { bubble: STATIC_MOTION, iris: STATIC_MOTION, pupil: STATIC_PUPIL } as const;
+  }
+};
+
+const createBlinkTimeline = (
+  cadence: number,
+  restingScale: number,
+  reduceMotion: boolean
+): MotionConfig => {
+  if (reduceMotion || !Number.isFinite(cadence) || cadence <= 0) {
+    return { animate: { scaleY: restingScale } };
+  }
+  return {
+    animate: { scaleY: [restingScale, restingScale, 1, restingScale] },
+    transition: {
+      duration: 1.1,
+      times: [0, 0.7, 0.78, 1],
+      repeat: Infinity,
+      repeatDelay: cadence,
+      ease: 'easeInOut',
+    },
+  };
+};
+
+export type EyeBubbleBaseProps = {
+  size?: number;
+  className?: string;
+  token: EyeBubbleToken;
+  reduceMotion?: boolean;
+  label: string;
+  role?: React.AriaRole;
+};
+
+const EyeBubbleBase: React.FC<EyeBubbleBaseProps> = ({
+  size = 44,
+  className = '',
+  token,
+  reduceMotion = false,
+  label,
+  role = 'img',
+}) => {
+  const dimension = size;
+  const irisSize = dimension * clamp(token.irisScale ?? 0.4, 0.2, 0.75);
+  const pupilSize = irisSize * clamp(token.pupilScale ?? 0.45, 0.1, 0.9);
+
+  const micro = createMicroMotion(token.microMotion, reduceMotion);
+
+  const bubbleMotion = token.animations?.bubble?.({ reduceMotion }) ?? micro.bubble;
+  const irisMotion = token.animations?.iris?.({ reduceMotion }) ?? micro.iris;
+  const pupilMotion = token.animations?.pupil?.({ reduceMotion }) ?? micro.pupil;
+
+  const restingScale = clamp(token.eyelidOffset ?? 0, 0, 0.95);
+  const eyelidMotion = token.animations?.eyelid?.({ reduceMotion, restingScale }) ??
+    createBlinkTimeline(token.blinkCadence, restingScale, reduceMotion);
+
+  return (
+    <div
+      className={`relative inline-flex select-none items-center justify-center ${className}`}
+      style={{ width: dimension, height: dimension }}
+    >
+      <motion.div
+        role={role}
+        aria-label={label}
+        className="relative flex items-center justify-center rounded-full"
+        style={{
+          width: dimension,
+          height: dimension,
+          background: `linear-gradient(135deg, ${token.gradient[0]}, ${token.gradient[1]})`,
+          border: '1px solid rgba(255,255,255,0.28)',
+          boxShadow:
+            '0 18px 34px rgba(15,23,42,0.18), inset 0 1px 18px rgba(255,255,255,0.45)',
+          backdropFilter: 'blur(16px)',
+          WebkitBackdropFilter: 'blur(16px)',
+        }}
+        animate={bubbleMotion.animate}
+        transition={bubbleMotion.transition}
+      >
+        <span
+          aria-hidden
+          className="absolute rounded-full"
+          style={{
+            inset: dimension * 0.18,
+            background: `radial-gradient(circle at 68% 22%, ${token.highlight[0]}, ${token.highlight[1]})`,
+          }}
+        />
+
+        <motion.div
+          aria-hidden
+          className="relative flex items-center justify-center rounded-full"
+          style={{
+            width: irisSize,
+            height: irisSize,
+            background: `radial-gradient(120% 120% at 32% 24%, ${token.irisGradient[0]}, ${token.irisGradient[1]})`,
+            boxShadow: 'inset 0 0 12px rgba(32, 54, 120, 0.35), inset 0 2px 8px rgba(255,255,255,0.45)',
+          }}
+          animate={irisMotion.animate}
+          transition={irisMotion.transition}
+        >
+          <motion.span
+            aria-hidden
+            className="block rounded-full"
+            style={{
+              width: pupilSize,
+              height: pupilSize,
+              background: token.pupilColor,
+              boxShadow: '0 4px 9px rgba(4, 10, 24, 0.45)',
+            }}
+            animate={pupilMotion.animate}
+            transition={pupilMotion.transition}
+          />
+
+          <motion.span
+            aria-hidden
+            className="absolute inset-0 origin-top rounded-full"
+            style={{
+              background:
+                token.eyelidSurface ?? 'linear-gradient(180deg, rgba(255,255,255,0.92), rgba(255,255,255,0.05))',
+            }}
+            animate={eyelidMotion.animate}
+            transition={eyelidMotion.transition}
+          />
+
+          <span
+            aria-hidden
+            className="absolute -top-[18%] left-[18%] h-[34%] w-[34%] rounded-full"
+            style={{
+              background: `radial-gradient(60% 60% at 50% 45%, ${token.irisHighlight[0]}, ${token.irisHighlight[1]})`,
+              filter: 'blur(0.4px)',
+              opacity: 0.8,
+            }}
+          />
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+};
+
+export default EyeBubbleBase;

--- a/src/components/memory/EmotionBubble.tsx
+++ b/src/components/memory/EmotionBubble.tsx
@@ -1,31 +1,50 @@
-import React from 'react';
-import { appleShade } from '../../pages/memory/palette';
+import React, { useMemo } from 'react';
+import { useReducedMotion } from 'framer-motion';
+
+import EyeBubbleBase, { EyeBubbleToken } from '../EyeBubbleBase';
+import { emotionEyelidSurface, getEmotionToken } from '../../pages/memory/emotionTokens';
 
 type EmotionBubbleProps = {
-  color?: string;
+  emotion?: string;
   className?: string;
+  size?: number;
   'aria-label'?: string;
 };
 
-const EmotionBubble: React.FC<EmotionBubbleProps> = ({ color = '#007aff', className = '', ...rest }) => (
-  <div
-    {...rest}
-    className={`h-11 w-11 rounded-full shrink-0 relative ${className}`}
-    style={{
-      background: `linear-gradient(135deg, ${color} 0%, ${appleShade(color, -0.15)} 100%)`,
-      boxShadow: `
-        0 0 0 0.5px rgba(0,0,0,0.04),
-        0 1px 2px rgba(0,0,0,0.06),
-        0 8px 16px ${color}25,
-        inset 0 0.5px 1px rgba(255,255,255,0.4)
-      `,
-    }}
-  >
-    <div
-      className="absolute inset-1 rounded-full"
-      style={{ background: 'radial-gradient(circle at 35% 30%, rgba(255,255,255,0.5) 0%, transparent 60%)' }}
+const EmotionBubble: React.FC<EmotionBubbleProps> = ({
+  emotion,
+  size = 44,
+  className = '',
+  'aria-label': ariaLabel,
+}) => {
+  const reduceMotion = useReducedMotion();
+  const data = useMemo(() => getEmotionToken(emotion), [emotion]);
+
+  const token: EyeBubbleToken = {
+    gradient: data.gradient,
+    highlight: data.highlight,
+    irisGradient: data.irisGradient,
+    irisHighlight: data.irisHighlight,
+    pupilColor: data.pupilColor,
+    irisScale: data.irisScale,
+    pupilScale: data.pupilScale,
+    eyelidOffset: data.eyelidOffset,
+    blinkCadence: data.blinkCadence,
+    microMotion: data.microMotion,
+    eyelidSurface: emotionEyelidSurface,
+  };
+
+  const label = ariaLabel ?? `Emoção: ${data.label}`;
+
+  return (
+    <EyeBubbleBase
+      className={className}
+      token={token}
+      size={size}
+      reduceMotion={reduceMotion}
+      label={label}
     />
-  </div>
-);
+  );
+};
 
 export default EmotionBubble;

--- a/src/components/memory/MemoryCard.tsx
+++ b/src/components/memory/MemoryCard.tsx
@@ -16,7 +16,8 @@ import {
   intensityOf,
   toDate,
 } from '../../pages/memory/utils';
-import { appleShade, getEmotionColor } from '../../pages/memory/palette';
+import { appleShade } from '../../pages/memory/palette';
+import { getEmotionToken } from '../../pages/memory/emotionTokens';
 
 type MemoryCardProps = {
   mem: Memoria;
@@ -27,7 +28,9 @@ const MemoryCardComponent: React.FC<MemoryCardProps> = ({ mem }) => {
   const toggle = useCallback(() => setOpen((value) => !value), []);
   const detailsId = `mem-details-${mem.id ?? Math.random().toString(36).slice(2)}`;
 
-  const primaryColor = getEmotionColor(getEmotion(mem));
+  const emotionName = getEmotion(mem);
+  const token = getEmotionToken(emotionName);
+  const primaryColor = token.accent;
   const when = humanDate(getCreatedAt(mem));
   const intensidade = intensityOf(mem);
 
@@ -41,7 +44,7 @@ const MemoryCardComponent: React.FC<MemoryCardProps> = ({ mem }) => {
       className="w-full max-w-full rounded-2xl bg-white/95 backdrop-blur-sm border border-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.05),0_8px_32px_rgba(0,0,0,0.04)] p-5 transition-all duration-200 hover:shadow-[0_1px_2px_rgba(0,0,0,0.08),0_12px_40px_rgba(0,0,0,0.06)] hover:border-black/[0.12]"
     >
       <div className="flex items-start gap-4">
-        <EmotionBubble aria-label={`Emoção: ${getEmotion(mem) || 'Neutro'}`} color={primaryColor} />
+        <EmotionBubble emotion={emotionName} />
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0 flex-1">

--- a/src/pages/memory/ProfileSection.tsx
+++ b/src/pages/memory/ProfileSection.tsx
@@ -4,6 +4,7 @@ import type { FC, PropsWithChildren, ReactNode } from 'react';
 import { useMemoryData } from './memoryData';
 import type { Memoria } from '../../api/memoriaApi';
 import { listarMemoriasBasico } from '../../api/memoriaApi';
+import { emotionPalette, resolveEmotionKey } from './emotionTokens';
 
 import EcoBubbleLoading from '../../components/EcoBubbleLoading';
 
@@ -33,13 +34,7 @@ class ChartErrorBoundary extends Component<PropsWithChildren<{}>, EBState> {
 }
 
 /* ---------- paleta ---------- */
-const EMOTION_COLORS: Record<string, string> = {
-  raiva: '#DB2777', irritado: '#EC4899', frustracao: '#BE185D', medo: '#DB2777', incerteza: '#BE185D',
-  alegria: '#3B82F6', calmo: '#2563EB', surpresa: '#06B6D4', antecipacao: '#2563EB',
-  tristeza: '#8B5CF6', neutro: '#94A3B8',
-};
-const normalize = (s = '') => s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-const colorForEmotion = (n: string) => EMOTION_COLORS[normalize(n)] || '#C7D2FE';
+const colorForEmotion = (n: string) => emotionPalette[resolveEmotionKey(n)] || '#C7D2FE';
 const hashHue = (str: string) => { let h = 0; for (let i=0;i<str.length;i++) h = str.charCodeAt(i)+((h<<5)-h); return Math.abs(h)%360; };
 const pastel = (str: string) => `hsl(${hashHue(str)}, 40%, 82%)`;
 

--- a/src/pages/memory/components/MemoryCard.tsx
+++ b/src/pages/memory/components/MemoryCard.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react';
-import type { Memoria } from '../../../api/memoriaApi';
-import {
-  generateConsistentPastelColor,
-  getEmotionColor,
-  humanDate,
-} from '../../../utils/memory';
 import { motion } from 'framer-motion';
+
+import type { Memoria } from '../../../api/memoriaApi';
+import EmotionBubble from '../../../components/memory/EmotionBubble';
+import { getEmotionToken } from '../emotionTokens';
+import { generateConsistentPastelColor, humanDate } from '../../../utils/memory';
 
 type Props = {
   mem: Memoria;
@@ -17,7 +16,9 @@ const capitalize = (value?: string | null) =>
 const MemoryCard: React.FC<Props> = ({ mem }) => {
   const [open, setOpen] = useState(false);
 
-  const color = getEmotionColor(mem.emocao_principal || 'neutro');
+  const emotionName = mem.emocao_principal || mem.emocao || 'neutro';
+  const token = getEmotionToken(emotionName);
+  const color = token.accent;
   const when = mem.created_at ? humanDate(mem.created_at) : '';
   const intensidade = Math.max(0, Math.min(10, Number((mem as any).intensidade ?? 0)));
   const preview = (mem.analise_resumo || mem.contexto || '').trim();
@@ -31,11 +32,7 @@ const MemoryCard: React.FC<Props> = ({ mem }) => {
         className="w-full text-left"
       >
         <div className="flex items-center gap-3">
-          <span
-            className="h-9 w-9 rounded-full ring-2 ring-white/70 shadow-sm shrink-0"
-            style={{ background: color, boxShadow: 'inset 0 1px 0 rgba(255,255,255,.6)' }}
-            aria-hidden
-          />
+          <EmotionBubble emotion={emotionName} size={36} className="shrink-0 ring-2 ring-white/70 shadow-sm" />
           <div className="min-w-0 flex-1">
             <div className="flex items-center justify-between gap-3">
               <h3 className="text-[15px] font-semibold text-neutral-900 truncate">

--- a/src/pages/memory/components/__tests__/MemoryCard.test.tsx
+++ b/src/pages/memory/components/__tests__/MemoryCard.test.tsx
@@ -20,6 +20,7 @@ describe('MemoryCard', () => {
   it('renders collapsed card with emotion, preview and tags', () => {
     render(<MemoryCard mem={baseMemory} />);
 
+    expect(screen.getByRole('img', { name: /emoção: alegria/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /alegria/i })).toBeInTheDocument();
     expect(screen.getByText('Resumo analítico')).toBeInTheDocument();
     expect(screen.getByText(/trabalho/i)).toBeInTheDocument();

--- a/src/pages/memory/emotionTokens.ts
+++ b/src/pages/memory/emotionTokens.ts
@@ -1,0 +1,186 @@
+import { normalizeText } from './utils';
+
+export type MicroMotionPattern =
+  | 'pulse'
+  | 'tremor'
+  | 'breathing'
+  | 'tracking'
+  | 'shortOscillation';
+
+export type EmotionKey =
+  | 'alegria'
+  | 'calmo'
+  | 'tristeza'
+  | 'surpresa'
+  | 'antecipacao'
+  | 'raiva'
+  | 'irritado'
+  | 'frustracao'
+  | 'medo'
+  | 'incerteza'
+  | 'neutro';
+
+export type EmotionToken = {
+  key: EmotionKey;
+  label: string;
+  gradient: [string, string];
+  highlight: [string, string];
+  irisGradient: [string, string];
+  irisHighlight: [string, string];
+  pupilColor: string;
+  irisScale: number;
+  pupilScale: number;
+  eyelidOffset: number;
+  blinkCadence: number;
+  microMotion: MicroMotionPattern;
+  accent: string;
+};
+
+const BASE_EYELID = 'linear-gradient(180deg, rgba(255,255,255,0.92), rgba(255,255,255,0.05))';
+
+const createToken = (
+  key: EmotionKey,
+  label: string,
+  options: Partial<EmotionToken> &
+    Pick<EmotionToken, 'gradient' | 'accent' | 'microMotion'>
+): EmotionToken => ({
+  key,
+  label,
+  highlight: ['rgba(255,255,255,0.75)', 'rgba(255,255,255,0.08)'],
+  irisGradient: ['rgba(124, 162, 255, 0.9)', 'rgba(64, 102, 200, 0.7)'],
+  irisHighlight: ['rgba(255,255,255,0.7)', 'rgba(255,255,255,0.1)'],
+  pupilColor: 'radial-gradient(120% 120% at 30% 30%, rgba(20,27,45,0.95), rgba(2,5,12,0.65))',
+  irisScale: 0.4,
+  pupilScale: 0.45,
+  eyelidOffset: 0.06,
+  blinkCadence: 4,
+  ...options,
+});
+
+export const emotionTokens: Record<EmotionKey, EmotionToken> = {
+  alegria: createToken('alegria', 'Alegria', {
+    gradient: ['#8EE3D0', '#4FD2A7'],
+    irisGradient: ['rgba(130, 220, 200, 0.95)', 'rgba(56, 166, 134, 0.75)'],
+    accent: '#4FD2A7',
+    blinkCadence: 5.2,
+    eyelidOffset: 0.04,
+    microMotion: 'pulse',
+  }),
+  calmo: createToken('calmo', 'Calmo', {
+    gradient: ['#C9B6FF', '#8EE3D0'],
+    irisGradient: ['rgba(182, 162, 255, 0.9)', 'rgba(92, 180, 176, 0.72)'],
+    irisHighlight: ['rgba(255,255,255,0.85)', 'rgba(255,255,255,0.12)'],
+    accent: '#A897FF',
+    blinkCadence: 6.4,
+    eyelidOffset: 0.12,
+    microMotion: 'breathing',
+  }),
+  tristeza: createToken('tristeza', 'Tristeza', {
+    gradient: ['#7A87A6', '#5B6B88'],
+    irisGradient: ['rgba(126, 142, 177, 0.92)', 'rgba(64, 86, 132, 0.7)'],
+    accent: '#5B6B88',
+    blinkCadence: 3.8,
+    eyelidOffset: 0.18,
+    microMotion: 'shortOscillation',
+  }),
+  surpresa: createToken('surpresa', 'Surpresa', {
+    gradient: ['#FFD166', '#FF9B42'],
+    irisGradient: ['rgba(255, 205, 102, 0.92)', 'rgba(244, 134, 48, 0.7)'],
+    accent: '#FF9B42',
+    blinkCadence: 2.8,
+    eyelidOffset: 0.02,
+    microMotion: 'tremor',
+  }),
+  antecipacao: createToken('antecipacao', 'Antecipação', {
+    gradient: ['#5B4BFF', '#8A6BFF'],
+    irisGradient: ['rgba(104, 94, 255, 0.92)', 'rgba(68, 48, 195, 0.75)'],
+    accent: '#6B59FF',
+    blinkCadence: 4.6,
+    eyelidOffset: 0.08,
+    microMotion: 'tracking',
+  }),
+  raiva: createToken('raiva', 'Raiva', {
+    gradient: ['#FF5964', '#FF7B87'],
+    irisGradient: ['rgba(255, 120, 130, 0.92)', 'rgba(172, 48, 74, 0.75)'],
+    accent: '#FF5964',
+    blinkCadence: 2.6,
+    eyelidOffset: 0.03,
+    microMotion: 'tremor',
+  }),
+  irritado: createToken('irritado', 'Irritado', {
+    gradient: ['#FF6B6F', '#FF8A7A'],
+    irisGradient: ['rgba(255, 140, 150, 0.9)', 'rgba(182, 58, 74, 0.7)'],
+    accent: '#FF6B6F',
+    blinkCadence: 3.2,
+    eyelidOffset: 0.05,
+    microMotion: 'shortOscillation',
+  }),
+  frustracao: createToken('frustracao', 'Frustração', {
+    gradient: ['#FF5964', '#C63F52'],
+    irisGradient: ['rgba(235, 108, 118, 0.92)', 'rgba(134, 34, 58, 0.76)'],
+    accent: '#E14F5A',
+    blinkCadence: 3,
+    eyelidOffset: 0.07,
+    microMotion: 'tracking',
+  }),
+  medo: createToken('medo', 'Medo', {
+    gradient: ['#5B4BFF', '#3E3DA8'],
+    irisGradient: ['rgba(112, 102, 255, 0.9)', 'rgba(46, 50, 162, 0.75)'],
+    accent: '#4A44D4',
+    blinkCadence: 2.9,
+    eyelidOffset: 0.15,
+    microMotion: 'tracking',
+  }),
+  incerteza: createToken('incerteza', 'Incerteza', {
+    gradient: ['#FFD166', '#FFB347'],
+    irisGradient: ['rgba(255, 202, 108, 0.92)', 'rgba(232, 153, 66, 0.74)'],
+    accent: '#FFB347',
+    blinkCadence: 3.6,
+    eyelidOffset: 0.09,
+    microMotion: 'breathing',
+  }),
+  neutro: createToken('neutro', 'Neutro', {
+    gradient: ['#7A87A6', '#8893AA'],
+    irisGradient: ['rgba(138, 150, 176, 0.92)', 'rgba(84, 95, 122, 0.72)'],
+    accent: '#7A87A6',
+    blinkCadence: 5.8,
+    eyelidOffset: 0.14,
+    microMotion: 'breathing',
+  }),
+};
+
+export const emotionEyelidSurface = BASE_EYELID;
+
+export const emotionAliases: Record<string, EmotionKey> = {
+  calma: 'calmo',
+  'bem-estar': 'alegria',
+  'bem estar': 'alegria',
+  bemestar: 'alegria',
+  plenitude: 'alegria',
+  raivoso: 'raiva',
+  assustado: 'medo',
+  medoansiedade: 'medo',
+  apreensivo: 'incerteza',
+};
+
+export const resolveEmotionKey = (emotion?: string): EmotionKey => {
+  const normalized = normalizeText(emotion ?? '');
+  if (!normalized) return 'neutro';
+  const mapped = emotionAliases[normalized];
+  if (mapped) return mapped;
+  if ((emotionTokens as Record<string, EmotionToken>)[normalized]) {
+    return normalized as EmotionKey;
+  }
+  return 'neutro';
+};
+
+export const getEmotionToken = (emotion?: string): EmotionToken => {
+  const key = resolveEmotionKey(emotion);
+  return emotionTokens[key];
+};
+
+export const emotionPalette: Record<EmotionKey, string> = Object.fromEntries(
+  Object.entries(emotionTokens).map(([key, token]) => [key, token.accent])
+) as Record<EmotionKey, string>;
+
+export const getEmotionAccent = (emotion?: string) => getEmotionToken(emotion).accent;

--- a/src/pages/memory/palette.ts
+++ b/src/pages/memory/palette.ts
@@ -1,32 +1,6 @@
-import { normalizeText } from './utils';
+import { getEmotionToken } from './emotionTokens';
 
-const EMOTION_COLORS: Record<string, string> = {
-  raiva: '#ff453a',
-  irritado: '#ff9f0a',
-  frustracao: '#ff375f',
-  medo: '#ff9f0a',
-  incerteza: '#ffd60a',
-  alegria: '#32d74b',
-  calmo: '#5ac8fa',
-  surpresa: '#007aff',
-  antecipacao: '#af52de',
-  tristeza: '#bf5af2',
-  neutro: '#98989d',
-};
-
-const EMOTION_ALIASES: Record<string, string> = {
-  calma: 'calmo',
-  'bem-estar': 'alegria',
-  'bem estar': 'alegria',
-  bemestar: 'alegria',
-  plenitude: 'alegria',
-};
-
-export const getEmotionColor = (emotion?: string) => {
-  const key = normalizeText(emotion ?? '');
-  const mapped = EMOTION_ALIASES[key] ?? key;
-  return EMOTION_COLORS[mapped] ?? EMOTION_COLORS.neutro;
-};
+export const getEmotionColor = (emotion?: string) => getEmotionToken(emotion).accent;
 
 const hashStringToHue = (str: string) => {
   let h = 0;

--- a/src/utils/__tests__/memory.test.ts
+++ b/src/utils/__tests__/memory.test.ts
@@ -33,7 +33,7 @@ describe('memory utils', () => {
     const pastel = generateConsistentPastelColor('empolgado');
     expect(pastel.startsWith('hsl(')).toBe(true);
     expect(getEmotionColor('empolgado')).toBe(pastel);
-    expect(getEmotionColor('Alegria')).toBe('#3B82F6');
+    expect(getEmotionColor('Alegria')).toBe('#4FD2A7');
   });
 
   it('formats human readable dates', () => {

--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -1,18 +1,5 @@
 import { Memoria } from '../api/memoriaApi';
-
-export const EMOTION_COLORS: Record<string, string> = {
-  raiva: '#DB2777',
-  irritado: '#EC4899',
-  frustracao: '#BE185D',
-  medo: '#DB2777',
-  incerteza: '#BE185D',
-  alegria: '#3B82F6',
-  calmo: '#2563EB',
-  surpresa: '#3B82F6',
-  antecipacao: '#2563EB',
-  tristeza: '#A855F7',
-  neutro: '#8B5CF6',
-};
+import { emotionAliases, emotionTokens } from '../pages/memory/emotionTokens';
 
 export const normalize = (value: string = ''): string =>
   value.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
@@ -36,7 +23,12 @@ export const generateConsistentPastelColor = (
 
 export const getEmotionColor = (emotionName: string): string => {
   const normalized = normalize(emotionName);
-  return EMOTION_COLORS[normalized] || generateConsistentPastelColor(emotionName);
+  const mapped = emotionAliases[normalized];
+  const key = mapped ?? normalized;
+  if ((emotionTokens as Record<string, { accent: string }>)[key]) {
+    return (emotionTokens as Record<string, { accent: string }>)[key].accent;
+  }
+  return generateConsistentPastelColor(emotionName);
 };
 
 export const humanDate = (raw: string): string => {


### PR DESCRIPTION
## Summary
- add an emotion token table and shared EyeBubbleBase component for configurable eye gradients, eyelids, and motion timelines
- refactor EcoBubbleOneEye and EmotionBubble to consume tokens and render animated emotion bubbles with reduced-motion fallbacks
- update memory cards, palette utilities, and tests to use the new palette while adjusting aria labels

## Testing
- npm run test -- MemoryCard

------
https://chatgpt.com/codex/tasks/task_e_68dbe24dd3ec832588e56a40f3e7b409