### PR TITLE
feat: add differentiated loading variants

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ const ReportSection = React.lazy(() => import('./pages/memory/ReportSection'));
 
 const memorySuspenseFallback = (
   <div className="flex min-h-[320px] items-center justify-center py-10">
-    <EcoBubbleLoading size={120} text="Carregando memórias..." />
+    <EcoBubbleLoading variant="memories" size={120} text="Carregando memórias..." />
   </div>
 );
 

--- a/src/components/EcoBubbleLoading.tsx
+++ b/src/components/EcoBubbleLoading.tsx
@@ -1,39 +1,233 @@
 import React from "react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
+
+import EyeBubbleBase from "./EyeBubbleBase";
+import { emotionTokens, type EmotionKey } from "../pages/memory/emotionTokens";
+
+type LoadingVariant = "global" | "memories";
 
 type Props = {
-  size?: number;       // px (default 64)
-  className?: string;  // classes extras
-  text?: string;       // texto opcional abaixo da bolha
-  breathingSec?: number; // duração de um ciclo (default 2s)
+  size?: number; // px (default 64)
+  className?: string; // classes extras
+  text?: string; // texto opcional abaixo da bolha
+  breathingSec?: number; // duração de um ciclo base (default 2s)
+  variant?: LoadingVariant;
 };
 
-const EcoBubbleLoading: React.FC<Props> = ({
-  size = 64,
-  className,
-  text = "Carregando...",
-  breathingSec = 2,
-}) => {
+const RING_CONFIG = [
+  { scale: [1, 1.08, 1], opacity: [0.35, 0.85, 0.35], duration: 2.6 },
+  { scale: [1, 1.12, 1], opacity: [0.28, 0.75, 0.28], duration: 3.3 },
+  { scale: [1, 1.16, 1], opacity: [0.18, 0.6, 0.18], duration: 4.1 },
+];
+
+const AVAILABLE_EMOTIONS = Object.keys(emotionTokens) as EmotionKey[];
+
+const pickRandomEmotionKeys = (count: number): EmotionKey[] => {
+  const shuffled = [...AVAILABLE_EMOTIONS].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, count);
+};
+
+type GlobalLoadingProps = {
+  size: number;
+  breathingSec: number;
+  reduceMotion: boolean;
+};
+
+const GlobalLoading: React.FC<GlobalLoadingProps> = ({ size, breathingSec, reduceMotion }) => {
+  const irisSize = size * 0.58;
+  const pupilSize = irisSize * 0.42;
+
   return (
-    <div className={`flex flex-col items-center justify-center ${className || ""}`}>
+    <div className="relative grid place-items-center" style={{ width: size, height: size }}>
+      {!reduceMotion &&
+        RING_CONFIG.map((config, index) => {
+          const ringSize = size * (1.1 + index * 0.22);
+          return (
+            <motion.div
+              key={index}
+              data-testid="global-ring"
+              data-duration={(breathingSec * config.duration).toFixed(2)}
+              aria-hidden
+              className="absolute rounded-full border border-indigo-100/40 shadow-[0_0_18px_rgba(79,70,229,0.18)]"
+              style={{
+                width: ringSize,
+                height: ringSize,
+              }}
+              animate={{
+                scale: config.scale,
+                opacity: config.opacity,
+              }}
+              transition={{
+                duration: breathingSec * config.duration,
+                repeat: Infinity,
+                ease: "easeInOut",
+                repeatDelay: 0.2 * (index + 1),
+              }}
+            />
+          );
+        })}
+
       <motion.div
-        className="rounded-full shadow-md ring-1 ring-[rgba(200,220,255,0.45)]"
+        aria-hidden
+        className="relative flex items-center justify-center rounded-full shadow-xl"
         style={{
           width: size,
           height: size,
           background:
-            "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.88), rgba(240,240,255,0.45))",
+            "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.9), rgba(200,210,255,0.5))",
           border: "1px solid rgba(200, 220, 255, 0.45)",
-          boxShadow: "0 6px 18px rgba(0, 0, 0, 0.10)",
-          backdropFilter: "blur(8px)",
-          WebkitBackdropFilter: "blur(8px)",
+          boxShadow: "0 18px 46px rgba(79,70,229,0.22)",
+          backdropFilter: "blur(12px)",
+          WebkitBackdropFilter: "blur(12px)",
         }}
-        animate={{ scale: [1, 1.1, 1] }}
-        transition={{ duration: breathingSec, repeat: Infinity, ease: "easeInOut" }}
-        aria-hidden
-      />
+        animate={reduceMotion ? { scale: 1 } : { scale: [1, 1.05, 1] }}
+        transition={{
+          duration: breathingSec * 1.4,
+          repeat: Infinity,
+          ease: "easeInOut",
+        }}
+      >
+        <motion.span
+          aria-hidden
+          className="relative flex items-center justify-center rounded-full"
+          style={{
+            width: irisSize,
+            height: irisSize,
+            background:
+              "radial-gradient(120% 120% at 32% 24%, rgba(130,162,255,0.92), rgba(64,82,200,0.72))",
+            boxShadow: "inset 0 0 18px rgba(32, 54, 120, 0.4)",
+          }}
+          animate={reduceMotion ? { scale: 1 } : { scale: [1, 1.04, 1] }}
+          transition={{
+            duration: breathingSec * 1.2,
+            repeat: Infinity,
+            ease: "easeInOut",
+          }}
+        >
+          <motion.span
+            aria-hidden
+            className="rounded-full"
+            style={{
+              width: pupilSize,
+              height: pupilSize,
+              background: "radial-gradient(125% 125% at 40% 35%, rgba(16,23,42,0.96), rgba(3,5,15,0.72))",
+              boxShadow: "0 8px 12px rgba(4, 6, 20, 0.55)",
+            }}
+            animate={reduceMotion ? { scale: 1 } : { scale: [1, 0.94, 1] }}
+            transition={{
+              duration: breathingSec,
+              repeat: Infinity,
+              ease: "easeInOut",
+            }}
+          />
+
+          <span
+            aria-hidden
+            className="absolute -top-[18%] left-[18%] h-[32%] w-[32%] rounded-full"
+            style={{
+              background:
+                "radial-gradient(60% 60% at 50% 45%, rgba(255,255,255,0.8), rgba(255,255,255,0.15))",
+              filter: "blur(0.4px)",
+            }}
+          />
+        </motion.span>
+      </motion.div>
+    </div>
+  );
+};
+
+type MemoriesLoadingProps = {
+  size: number;
+  reduceMotion: boolean;
+  tokens: EmotionKey[];
+};
+
+const TRACKING_SEQUENCE = {
+  x: [0, -6, 4, -3, 6, 0],
+  y: [0, 1.5, -1.5, 0.5, -1, 0],
+};
+
+const MemoriesLoading: React.FC<MemoriesLoadingProps> = ({ size, reduceMotion, tokens }) => {
+  const bubbleSize = Math.max(28, Math.min(size, 56));
+
+  return (
+    <div className="flex items-center justify-center gap-4">
+      {tokens.map((tokenKey, index) => {
+        const token = emotionTokens[tokenKey];
+        const delay = index * 0.45;
+        return (
+          <motion.div
+            key={`${tokenKey}-${index}`}
+            data-testid="memories-eye"
+            data-emotion={token.label}
+            data-delay={delay.toFixed(2)}
+            className="relative"
+            animate={
+              reduceMotion
+                ? { scale: 1 }
+                : {
+                    x: TRACKING_SEQUENCE.x,
+                    y: TRACKING_SEQUENCE.y,
+                  }
+            }
+            transition={
+              reduceMotion
+                ? { duration: 0 }
+                : {
+                    duration: 3.8,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                    delay,
+                  }
+            }
+          >
+            <EyeBubbleBase
+              size={bubbleSize}
+              token={{
+                ...token,
+                irisScale: Math.min(token.irisScale + 0.08, 0.62),
+                pupilScale: token.pupilScale,
+                blinkCadence: Math.max(token.blinkCadence, 3.2),
+              }}
+              reduceMotion={reduceMotion}
+              label={`Bolha de emoção ${token.label}`}
+            />
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+};
+
+const EcoBubbleLoading: React.FC<Props> = ({
+  size = 64,
+  className = "",
+  text = "Carregando...",
+  breathingSec = 2,
+  variant = "global",
+}) => {
+  const reduceMotion = useReducedMotion();
+  const selectedTokens = React.useMemo(
+    () => (variant === "memories" ? pickRandomEmotionKeys(3) : []),
+    [variant]
+  );
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={text}
+      className={`flex flex-col items-center justify-center text-center ${className}`}
+    >
+      {variant === "memories" ? (
+        <MemoriesLoading size={size} reduceMotion={reduceMotion} tokens={selectedTokens} />
+      ) : (
+        <GlobalLoading size={size} breathingSec={breathingSec} reduceMotion={reduceMotion} />
+      )}
       {text && (
-        <span className="mt-4 text-sm text-gray-500 select-none">{text}</span>
+        <span className="mt-4 text-sm text-slate-500 select-none" data-testid="loading-text">
+          {text}
+        </span>
       )}
     </div>
   );

--- a/src/components/__tests__/EcoBubbleLoading.test.tsx
+++ b/src/components/__tests__/EcoBubbleLoading.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import EcoBubbleLoading from '../EcoBubbleLoading';
+
+beforeAll(() => {
+  if (!window.matchMedia) {
+    // framer-motion rely on matchMedia for reduced motion queries
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  }
+});
+
+describe('EcoBubbleLoading', () => {
+  it('renders the global variant with concentric rings and accessible status label', () => {
+    render(
+      <EcoBubbleLoading
+        text="Carregando dados globais"
+        breathingSec={2}
+        size={96}
+      />
+    );
+
+    const status = screen.getByRole('status', { name: /Carregando dados globais/i });
+    expect(status).toBeInTheDocument();
+
+    const rings = screen.getAllByTestId('global-ring');
+    expect(rings).toHaveLength(3);
+    rings.forEach((ring) => {
+      expect(ring).toHaveAttribute('data-duration');
+    });
+
+    expect(screen.getByTestId('loading-text')).toHaveTextContent('Carregando dados globais');
+  });
+
+  it('renders the memories variant with three animated eyes and accessible status', () => {
+    render(
+      <EcoBubbleLoading
+        variant="memories"
+        text="Carregando memórias..."
+        size={48}
+      />
+    );
+
+    const status = screen.getByRole('status', { name: /Carregando memórias/i });
+    expect(status).toBeInTheDocument();
+
+    const eyes = screen.getAllByTestId('memories-eye');
+    expect(eyes).toHaveLength(3);
+    eyes.forEach((eye) => {
+      expect(eye.getAttribute('data-emotion')).toBeTruthy();
+      expect(eye).toHaveAttribute('data-delay');
+    });
+
+    expect(screen.getByTestId('loading-text')).toHaveTextContent('Carregando memórias...');
+  });
+});

--- a/src/pages/memory/MemoriesSection.tsx
+++ b/src/pages/memory/MemoriesSection.tsx
@@ -28,7 +28,12 @@ const MemoriesSection: React.FC = () => {
   if (memoriesLoading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <EcoBubbleLoading size={120} text="Carregando memórias..." breathingSec={2} />
+        <EcoBubbleLoading
+          variant="memories"
+          size={120}
+          text="Carregando memórias..."
+          breathingSec={2}
+        />
       </div>
     );
   }

--- a/src/pages/memory/MemoryLayout.tsx
+++ b/src/pages/memory/MemoryLayout.tsx
@@ -160,7 +160,11 @@ const MemoryLayout: React.FC = () => {
 
           {state.memoriesLoading && state.perfilLoading && state.relatorioLoading ? (
             <div className="h-[calc(100%-0px)] min-h-[320px] flex items-center justify-center">
-              <EcoBubbleLoading size={120} text="Carregando dados..." />
+              <EcoBubbleLoading
+                variant="memories"
+                size={120}
+                text="Carregando dados..."
+              />
             </div>
           ) : (
             <Outlet />

--- a/src/pages/memory/ProfileSection.tsx
+++ b/src/pages/memory/ProfileSection.tsx
@@ -233,7 +233,7 @@ const ProfileSection: FC = () => {
       <div className="mx-auto w-full max-w-[980px] px-4 md:px-6 py-6 md:py-8 space-y-8 md:space-y-10">
         {(perfilLoading || memoriesLoading || fetchingLocal) && (
           <div className="rounded-2xl border border-neutral-200 bg-white px-4 py-10 grid place-items-center">
-            <EcoBubbleLoading size={72} text="Carregando…" />
+            <EcoBubbleLoading variant="memories" size={72} text="Carregando…" />
           </div>
         )}
         {(() => {
@@ -270,7 +270,13 @@ const ProfileSection: FC = () => {
             <div className="h-[96px]">
               {isClient && hasLinePoints ? (
                 <ChartErrorBoundary>
-                  <Suspense fallback={<div className="w-full h-full grid place-items-center"><EcoBubbleLoading size={28} /></div>}>
+                <Suspense
+                  fallback={
+                    <div className="w-full h-full grid place-items-center">
+                      <EcoBubbleLoading variant="memories" size={28} />
+                    </div>
+                  }
+                >
                     {/* usa cópia mutável */}
                     <LazyResponsiveLine
                       key={`line-${period}`}
@@ -311,7 +317,13 @@ const ProfileSection: FC = () => {
           {isClient && emotionsDataSafe.length ? (
             <div className="h-[300px]">
               <ChartErrorBoundary>
-                <Suspense fallback={<div className="w-full h-full grid place-items-center"><EcoBubbleLoading size={32} /></div>}>
+                <Suspense
+                  fallback={
+                    <div className="w-full h-full grid place-items-center">
+                      <EcoBubbleLoading variant="memories" size={32} />
+                    </div>
+                  }
+                >
                   {/* usa cópia mutável */}
                   <LazyResponsiveBar
                     key={`bar-emo-${period}`}
@@ -357,7 +369,13 @@ const ProfileSection: FC = () => {
           {isClient && themesDataSafe.length ? (
             <div className="h-[300px]">
               <ChartErrorBoundary>
-                <Suspense fallback={<div className="w-full h-full grid place-items-center"><EcoBubbleLoading size={32} /></div>}>
+                <Suspense
+                  fallback={
+                    <div className="w-full h-full grid place-items-center">
+                      <EcoBubbleLoading variant="memories" size={32} />
+                    </div>
+                  }
+                >
                   {/* usa cópia mutável */}
                   <LazyResponsiveBar
                     key={`bar-theme-${period}`}

--- a/src/pages/memory/ReportSection.tsx
+++ b/src/pages/memory/ReportSection.tsx
@@ -155,13 +155,13 @@ const ReportSection: React.FC = () => {
         <div className="grid grid-cols-1 gap-4">
           <Card title="Carregando análise…">
             <div className="h-48 grid place-items-center">
-              <EcoBubbleLoading size={80} text="Preparando seu relatório..." />
+              <EcoBubbleLoading variant="memories" size={80} text="Preparando seu relatório..." />
             </div>
           </Card>
 
           <Card title="Carregando visualizações…">
             <div className="h-56 grid place-items-center">
-              <EcoBubbleLoading size={60} />
+              <EcoBubbleLoading variant="memories" size={60} />
             </div>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- add global and memories variants to EcoBubbleLoading with reduced-motion handling and new animations
- update memory-related suspense fallbacks to request the memories variant
- add unit coverage for both loading variants to verify accessibility and animation metadata

## Testing
- npm run test -- --watch=false
- npx vitest run src/components/__tests__/EcoBubbleLoading.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68dbe6b3d8808325b9f70869402435b1