### PR TITLE
Remove Mixpanel token logging

### DIFF
--- a/src/lib/mixpanel.ts
+++ b/src/lib/mixpanel.ts
@@ -5,6 +5,8 @@ mixpanel.init(import.meta.env.VITE_MIXPANEL_TOKEN || '', {
   api_host: 'https://api-eu.mixpanel.com'
 });
 
-console.log('MIXPANEL TOKEN:', import.meta.env.VITE_MIXPANEL_TOKEN); // ✅ Adicione aqui
+if (!import.meta.env.VITE_MIXPANEL_TOKEN) {
+  console.warn('Mixpanel token is not configured.');
+}
 
 export default mixpanel;


### PR DESCRIPTION
## Summary
- replace the Mixpanel console log with a conditional warning when the token is missing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbedc944a083259ff08a1fbd4f0d00