### PR TITLE
Add Mixpanel tracking for login events

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -7,6 +7,7 @@ import PhoneFrame from '../components/PhoneFrame';
 import { useAuth } from '../contexts/AuthContext';
 import TourInicial from '../components/TourInicial';
 import EcoBubbleOneEye from '../components/EcoBubbleOneEye';
+import mixpanel from '../lib/mixpanel';
 import { supabase } from '@/lib/supabase';
 
 /* Divisor com traço mais marcado */
@@ -113,9 +114,18 @@ const LoginPage: React.FC = () => {
     setError('');
     setLoading(true);
     try {
+      mixpanel.track('Front-end: Login Iniciado', {
+        method: 'password',
+        email: email.trim(),
+      });
       await signIn(email.trim(), password);
+      mixpanel.track('Front-end: Login Concluído', { method: 'password' });
     } catch (err: any) {
       setError(translateAuthError(err));
+      mixpanel.track('Front-end: Login Falhou', {
+        method: 'password',
+        reason: translateAuthError(err),
+      });
     } finally {
       setLoading(false);
     }
@@ -125,10 +135,16 @@ const LoginPage: React.FC = () => {
     setError('');
     setLoading(true);
     try {
+      mixpanel.track('Front-end: Login Iniciado', { method: 'google' });
       await signInWithGoogle();
+      mixpanel.track('Front-end: Login Concluído', { method: 'google' });
     } catch (err: any) {
       setLoading(false);
       setError(translateAuthError(err));
+      mixpanel.track('Front-end: Login Falhou', {
+        method: 'google',
+        reason: translateAuthError(err),
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- add mixpanel integration to LoginPage for password login start, success, and failure events
- instrument Google login with mixpanel tracking for initiation, completion, and error handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbf15ecdc48325a6cc95101dff0007