### PR TITLE
Add meta tracking for quick suggestion picks

### DIFF
--- a/src/components/QuickSuggestions.tsx
+++ b/src/components/QuickSuggestions.tsx
@@ -10,13 +10,18 @@ export type Suggestion = {
   systemHint?: string;    // dica extra para a IA ajustar o tom
 };
 
+export type SuggestionPickMeta = {
+  source: "rotating" | "pill";
+  index: number;
+};
+
 type QuickSuggestionsProps = {
   visible: boolean;
   className?: string;
 
   /** Preferencial — recebe objetos ricos */
   suggestions?: Suggestion[];
-  onPickSuggestion?: (s: Suggestion) => void;
+  onPickSuggestion?: (s: Suggestion, meta?: SuggestionPickMeta) => void;
 
   /** Legado: compat com versão antiga (texto direto) */
   onPick?: (text: string) => void;
@@ -135,8 +140,8 @@ export default function QuickSuggestions({
 }: QuickSuggestionsProps) {
   if (!visible) return null;
 
-  const emitPick = (s: Suggestion) => {
-    if (onPickSuggestion) return onPickSuggestion(s);
+  const emitPick = (s: Suggestion, meta?: SuggestionPickMeta) => {
+    if (onPickSuggestion) return onPickSuggestion(s, meta);
     if (onPick) return onPick(`${s.icon ? s.icon + " " : ""}${s.label}`);
   };
 
@@ -170,10 +175,10 @@ export default function QuickSuggestions({
           [&::-webkit-scrollbar]:hidden
         "
       >
-        {suggestions.map((s) => (
+        {suggestions.map((s, index) => (
           <button
             key={s.id}
-            onClick={() => emitPick(s)}
+            onClick={() => emitPick(s, { source: "pill", index })}
             className="
               shrink-0 md:shrink
               h-9 md:h-10

--- a/src/components/RotatingPrompts.tsx
+++ b/src/components/RotatingPrompts.tsx
@@ -1,10 +1,10 @@
 // src/components/RotatingPrompts.tsx
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import type { Suggestion } from "./QuickSuggestions";
+import type { Suggestion, SuggestionPickMeta } from "./QuickSuggestions";
 
 type Props = {
   items: Suggestion[];
-  onPick: (s: Suggestion) => void;
+  onPick: (s: Suggestion, meta?: SuggestionPickMeta) => void;
   /** intervalo de troca em ms (default 4500) */
   intervalMs?: number;
   className?: string;
@@ -52,7 +52,7 @@ const RotatingPrompts: React.FC<Props> = ({
     >
       <button
         type="button"
-        onClick={() => onPick(s)}
+        onClick={() => onPick(s, { source: "rotating", index: idx })}
         onFocus={() => (pauseRef.current = true)}
         onBlur={() => (pauseRef.current = false)}
         className="

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -11,7 +11,7 @@ import ChatMessage from '../components/ChatMessage';
 import ChatInput from '../components/ChatInput';
 import EcoBubbleOneEye from '../components/EcoBubbleOneEye';
 import EcoMessageWithAudio from '../components/EcoMessageWithAudio';
-import QuickSuggestions, { Suggestion } from '../components/QuickSuggestions';
+import QuickSuggestions, { Suggestion, SuggestionPickMeta } from '../components/QuickSuggestions';
 import TypingDots from '../components/TypingDots';
 
 import { enviarMensagemParaEco } from '../api/ecoApi';
@@ -304,9 +304,15 @@ const ChatPage: React.FC = () => {
     }
   };
 
-  const handlePickSuggestion = async (s: Suggestion) => {
+  const handlePickSuggestion = async (s: Suggestion, meta?: SuggestionPickMeta) => {
     setShowQuick(false);
-    mixpanel.track('Eco: QuickSuggestion Click', { id: s.id, label: s.label, modules: s.modules });
+    mixpanel.track('Front-end: Quick Suggestion', {
+      id: s.id,
+      label: s.label,
+      source: meta?.source,
+      index: meta?.index,
+      modules: s.modules,
+    });
     const hint =
       (s.modules?.length || s.systemHint)
         ? `${s.modules?.length ? `Ative módulos: ${s.modules.join(', ')}.` : ''}${s.systemHint ? ` ${s.systemHint}` : ''}`.trim()


### PR DESCRIPTION
## Summary
- extend quick suggestion props to include pick metadata with source and index
- propagate metadata from rotating prompts and pills to the chat page handler
- update Mixpanel tracking to log source and index details for quick suggestions

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf8abc90c8325aabbedb397ea0e8e