### PR TITLE
Add Mixpanel route listener for page view tracking

### DIFF
--- a/src/lib/MixpanelRouteListener.tsx
+++ b/src/lib/MixpanelRouteListener.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import mixpanel from './mixpanel';
+
+export default function MixpanelRouteListener() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const { pathname, search } = location;
+
+    mixpanel.register({ last_page: pathname });
+    mixpanel.track('Front-end: Page View', {
+      path: pathname,
+      search
+    });
+  }, [location.pathname, location.search]);
+
+  return null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import './index.css';
 
 import { initFacebookPixel } from './lib/fbpixel';
 import PixelRouteListener from './lib/PixelRouteListener';
+import MixpanelRouteListener from './lib/MixpanelRouteListener';
 
 // inicia o Pixel uma única vez
 initFacebookPixel();
@@ -16,6 +17,7 @@ createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       {/* dispara PageView em cada navegação */}
       <PixelRouteListener />
+      <MixpanelRouteListener />
       <App />
     </BrowserRouter>
   </StrictMode>


### PR DESCRIPTION
## Summary
- add a Mixpanel route listener that registers the last page and sends page view events
- render the Mixpanel listener alongside the existing Facebook Pixel listener

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbfb9f2fb88325be7a6dfc71c877e5