### PR TITLE
Handle Eco deep question feedback gating

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -7,6 +7,8 @@ import React, {
   useEffect,
   useRef,
   ReactNode,
+  Dispatch,
+  SetStateAction,
 } from 'react';
 import { useAuth } from './AuthContext';
 
@@ -16,6 +18,7 @@ export interface Message {
   content?: string;
   sender: 'user' | 'eco';
   role?: 'user' | 'assistant' | 'system';
+  deepQuestion?: boolean;
 }
 
 interface ChatContextType {
@@ -23,7 +26,7 @@ interface ChatContextType {
   addMessage: (message: Message) => void;
   clearMessages: () => void;
   updateMessage: (messageId: string, newText: string) => void;
-  setMessages: (messages: Message[]) => void;
+  setMessages: Dispatch<SetStateAction<Message[]>>;
 }
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);


### PR DESCRIPTION
## Summary
- extend chat messages with an optional `deepQuestion` flag so Eco replies can be marked for follow-up
- detect "pergunta profunda" indicators in Eco responses and attach the flag when storing the message
- show the feedback prompt only for flagged Eco messages and clear the flag after submitting feedback

## Testing
- npm run lint *(fails: existing lint errors throughout the project unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68dc20ef8d048325957ac8ff32478914