### PR TITLE
Refine Eco bubble loading spinner

### DIFF
--- a/src/components/EcoBubbleLoading.tsx
+++ b/src/components/EcoBubbleLoading.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { motion } from "framer-motion";
 
+import EcoBubbleOneEye from "./EcoBubbleOneEye";
+
 type Props = {
   size?: number;       // px (default 64)
   className?: string;  // classes extras
@@ -14,24 +16,43 @@ const EcoBubbleLoading: React.FC<Props> = ({
   text = "Carregando...",
   breathingSec = 2,
 }) => {
+  const haloSize = size * 1.35;
+
   return (
     <div className={`flex flex-col items-center justify-center ${className || ""}`}>
-      <motion.div
-        className="rounded-full shadow-md ring-1 ring-[rgba(200,220,255,0.45)]"
-        style={{
-          width: size,
-          height: size,
-          background:
-            "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.88), rgba(240,240,255,0.45))",
-          border: "1px solid rgba(200, 220, 255, 0.45)",
-          boxShadow: "0 6px 18px rgba(0, 0, 0, 0.10)",
-          backdropFilter: "blur(8px)",
-          WebkitBackdropFilter: "blur(8px)",
-        }}
-        animate={{ scale: [1, 1.1, 1] }}
-        transition={{ duration: breathingSec, repeat: Infinity, ease: "easeInOut" }}
-        aria-hidden
-      />
+      <div
+        className="relative flex items-center justify-center"
+        style={{ width: haloSize, height: haloSize }}
+      >
+        <motion.div
+          aria-hidden
+          className="absolute rounded-full blur-xl"
+          style={{
+            width: haloSize,
+            height: haloSize,
+            background:
+              "radial-gradient(65% 65% at 50% 50%, rgba(171, 197, 255, 0.32), rgba(92, 132, 227, 0.08))",
+            boxShadow: "0 24px 42px rgba(40, 60, 120, 0.18)",
+          }}
+          animate={{ scale: [1, 1.04, 1] }}
+          transition={{ duration: breathingSec, repeat: Infinity, ease: "easeInOut" }}
+        />
+
+        <motion.div
+          aria-hidden
+          className="absolute inset-0 rounded-full"
+          style={{
+            border: "1px solid rgba(200, 220, 255, 0.25)",
+            background:
+              "radial-gradient(55% 55% at 30% 30%, rgba(255,255,255,0.48), rgba(216,228,255,0.15))",
+          }}
+          animate={{ opacity: [0.65, 0.9, 0.65] }}
+          transition={{ duration: breathingSec * 1.1, repeat: Infinity, ease: "easeInOut" }}
+        />
+
+        <EcoBubbleOneEye state="thinking" size={size} />
+      </div>
+
       {text && (
         <span className="mt-4 text-sm text-gray-500 select-none">{text}</span>
       )}


### PR DESCRIPTION
## Summary
- replace the ad-hoc loading bubble with the EcoBubbleOneEye avatar in thinking mode
- wrap the avatar with a softly animated halo and glow to match the refreshed artwork

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc28f9f16c83259849eea3e3b67cdf