### PR TITLE
Refresh memory emotion visuals

### DIFF
--- a/src/components/memory/EmotionBubble.tsx
+++ b/src/components/memory/EmotionBubble.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useReducedMotion } from 'framer-motion';
 
 import EyeBubbleBase, { EyeBubbleToken } from '../EyeBubbleBase';
+import { appleShade } from '../../pages/memory/palette';
 import { emotionEyelidSurface, getEmotionToken } from '../../pages/memory/emotionTokens';
 
 type EmotionBubbleProps = {
@@ -11,9 +12,20 @@ type EmotionBubbleProps = {
   'aria-label'?: string;
 };
 
+const toRgb = (hex?: string) => {
+  if (!hex) return null;
+  const sanitized = hex.replace('#', '');
+  if (sanitized.length !== 6) return null;
+  const bigint = Number.parseInt(sanitized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return { r, g, b };
+};
+
 const EmotionBubble: React.FC<EmotionBubbleProps> = ({
   emotion,
-  size = 44,
+  size = 48,
   className = '',
   'aria-label': ariaLabel,
 }) => {
@@ -36,14 +48,52 @@ const EmotionBubble: React.FC<EmotionBubbleProps> = ({
 
   const label = ariaLabel ?? `Emoção: ${data.label}`;
 
+  const accentLight = useMemo(() => appleShade(data.accent, 0.22), [data.accent]);
+  const accentDark = useMemo(() => appleShade(data.accent, -0.25), [data.accent]);
+  const accentRgb = useMemo(() => toRgb(data.accent), [data.accent]);
+
+  const frameShadow = accentRgb
+    ? `0 18px 42px rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0.25)`
+    : '0 18px 42px rgba(15, 23, 42, 0.18)';
+
+  const padding = Math.max(8, Math.round(size * 0.22));
+  const frameSize = size + padding * 2;
+
   return (
-    <EyeBubbleBase
-      className={className}
-      token={token}
-      size={size}
-      reduceMotion={reduceMotion}
-      label={label}
-    />
+    <div
+      className={`group relative inline-flex items-center justify-center ${className}`}
+      style={{ width: frameSize, height: frameSize }}
+    >
+      <span
+        aria-hidden
+        className="absolute inset-0 rounded-[22px] transition-shadow duration-500 ease-[cubic-bezier(0.22,0.61,0.36,1)]"
+        style={{
+          background: `linear-gradient(135deg, ${accentLight}, ${accentDark})`,
+          boxShadow: `${frameShadow}, inset 0 1px 0 rgba(255,255,255,0.48)`,
+        }}
+      />
+      <span
+        aria-hidden
+        className="absolute inset-[1.2px] rounded-[20px] border border-white/45 bg-white/35 backdrop-blur-2xl transition duration-500 ease-[cubic-bezier(0.22,0.61,0.36,1)] group-hover:bg-white/45"
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute -inset-3 rounded-[26px] opacity-0 transition duration-500 ease-[cubic-bezier(0.22,0.61,0.36,1)] group-hover:opacity-60"
+        style={{
+          background: accentRgb
+            ? `radial-gradient(120% 120% at 20% 0%, rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0.35), transparent 65%)`
+            : 'radial-gradient(120% 120% at 20% 0%, rgba(79, 70, 229, 0.28), transparent 65%)',
+        }}
+      />
+
+      <EyeBubbleBase
+        className="relative transition-transform duration-[600ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:-translate-y-0.5 group-hover:scale-[1.04]"
+        token={token}
+        size={size}
+        reduceMotion={reduceMotion}
+        label={label}
+      />
+    </div>
   );
 };
 

--- a/src/pages/memory/components/MemoryCard.tsx
+++ b/src/pages/memory/components/MemoryCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 
 import type { Memoria } from '../../../api/memoriaApi';
@@ -13,37 +13,72 @@ type Props = {
 const capitalize = (value?: string | null) =>
   value ? value.charAt(0).toUpperCase() + value.slice(1) : '';
 
+const toRgb = (hex?: string) => {
+  if (!hex) return null;
+  const sanitized = hex.replace('#', '');
+  if (sanitized.length !== 6) return null;
+  const bigint = Number.parseInt(sanitized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return { r, g, b };
+};
+
 const MemoryCard: React.FC<Props> = ({ mem }) => {
   const [open, setOpen] = useState(false);
 
   const emotionName = mem.emocao_principal || mem.emocao || 'neutro';
   const token = getEmotionToken(emotionName);
   const color = token.accent;
+  const colorRgb = useMemo(() => toRgb(color), [color]);
   const when = mem.created_at ? humanDate(mem.created_at) : '';
   const intensidade = Math.max(0, Math.min(10, Number((mem as any).intensidade ?? 0)));
   const preview = (mem.analise_resumo || mem.contexto || '').trim();
 
   return (
-    <li className="rounded-3xl border border-black/10 bg-white/70 backdrop-blur-md shadow-md p-4 transition-all">
+    <li
+      className="group relative overflow-hidden rounded-[26px] border border-white/60 bg-white/80 px-5 py-5 backdrop-blur-2xl transition-shadow duration-300"
+      style={{
+        boxShadow: colorRgb
+          ? `0 18px 46px rgba(${colorRgb.r}, ${colorRgb.g}, ${colorRgb.b}, 0.2), 0 12px 28px rgba(15,23,42,0.08)`
+          : '0 18px 46px rgba(15,23,42,0.14)',
+      }}
+    >
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 rounded-[26px] opacity-70"
+        style={{
+          background: 'linear-gradient(135deg, rgba(255,255,255,0.75), rgba(255,255,255,0.28))',
+        }}
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute -inset-px rounded-[28px] opacity-0 transition duration-500 ease-[cubic-bezier(0.22,0.61,0.36,1)] group-hover:opacity-60"
+        style={{
+          background: colorRgb
+            ? `radial-gradient(140% 140% at 85% 12%, rgba(${colorRgb.r}, ${colorRgb.g}, ${colorRgb.b}, 0.22), transparent 65%)`
+            : 'radial-gradient(140% 140% at 85% 12%, rgba(79,70,229,0.2), transparent 65%)',
+        }}
+      />
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
-        className="w-full text-left"
+        className="relative w-full text-left"
       >
-        <div className="flex items-center gap-3">
-          <EmotionBubble emotion={emotionName} size={36} className="shrink-0 ring-2 ring-white/70 shadow-sm" />
-          <div className="min-w-0 flex-1">
+        <div className="flex items-start gap-5">
+          <EmotionBubble emotion={emotionName} size={54} />
+          <div className="min-w-0 flex-1 pt-1">
             <div className="flex items-center justify-between gap-3">
-              <h3 className="text-[15px] font-semibold text-neutral-900 truncate">
+              <h3 className="truncate text-[17px] font-semibold leading-[1.35] text-neutral-900">
                 {capitalize(mem.emocao_principal) || 'Emoção'}
               </h3>
-              <span className="text-[12px] text-neutral-500 shrink-0">{when}</span>
+              <span className="shrink-0 text-[12px] font-medium text-neutral-500">{when}</span>
             </div>
 
             {preview && (
               <p
-                className="text-sm text-neutral-700 mt-0.5"
+                className="mt-1 text-[13.5px] leading-[1.45] text-neutral-700"
                 style={{
                   display: '-webkit-box',
                   WebkitLineClamp: 2,
@@ -57,22 +92,25 @@ const MemoryCard: React.FC<Props> = ({ mem }) => {
           </div>
         </div>
 
-        <div className="mt-3 h-1.5 rounded-full bg-neutral-200/60 overflow-hidden">
+        <div className="relative mt-4 h-2 rounded-full bg-neutral-200/70">
           <span
-            className="block h-full rounded-full"
+            className="absolute inset-y-0 block rounded-full"
             style={{
               width: `${(intensidade / 10) * 100}%`,
               background: `linear-gradient(90deg, ${color}, rgba(0,0,0,0.08))`,
+              boxShadow: colorRgb
+                ? `0 8px 16px rgba(${colorRgb.r}, ${colorRgb.g}, ${colorRgb.b}, 0.22)`
+                : undefined,
             }}
             aria-hidden
           />
         </div>
 
         {!!mem.tags?.length && (
-          <div className="mt-3 flex flex-wrap gap-2">
-            {mem.tags.map((tag, i) => (
-              <span
-                key={`${tag}-${i}`}
+        <div className="mt-4 flex flex-wrap gap-2">
+          {mem.tags.map((tag, i) => (
+            <span
+              key={`${tag}-${i}`}
                 className="text-xs px-3 py-1 rounded-full font-medium border border-black/10 shadow-sm"
                 style={{ background: generateConsistentPastelColor(tag), color: '#0f172a' }}
               >
@@ -82,7 +120,7 @@ const MemoryCard: React.FC<Props> = ({ mem }) => {
           </div>
         )}
 
-        <div className="mt-3 flex justify-end">
+        <div className="mt-4 flex justify-end">
           <span className="text-xs font-medium text-sky-700">{open ? 'Fechar ↑' : 'Ver mais ↓'}</span>
         </div>
       </button>


### PR DESCRIPTION
## Summary
- wrap the emotion eye in a new gradient tile with hover lighting while keeping EyeBubbleBase animations
- refresh the reusable memory card shell to match the updated tile sizing, spacing, and accent glow
- align the in-page memory card to the same styling cues for consistency across the memory view

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2a1e49208325bec174d3077eeae4