### PR TITLE
Normalize Eco API response parsing

### DIFF
--- a/src/api/__tests__/ecoApi.test.ts
+++ b/src/api/__tests__/ecoApi.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const { postMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+}));
+
+vi.mock("../axios", () => ({
+  default: {
+    post: postMock,
+  },
+}));
+
+vi.mock("uuid", () => ({
+  v4: () => "uuid-mock",
+}));
+
+import { enviarMensagemParaEco } from "../ecoApi";
+
+const mensagens = [
+  { role: "user", content: "Olá" },
+  { role: "assistant", content: "Oi" },
+  { role: "user", content: "Tudo bem?" },
+];
+
+describe("enviarMensagemParaEco", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  const callApi = async () => enviarMensagemParaEco(mensagens);
+
+  it("extrai texto de strings simples", async () => {
+    postMock.mockResolvedValue({ data: { message: "Resposta direta" }, status: 200 });
+
+    await expect(callApi()).resolves.toBe("Resposta direta");
+  });
+
+  it("extrai texto de objetos com content", async () => {
+    postMock.mockResolvedValue({ data: { message: { content: "Texto interno" } }, status: 200 });
+
+    await expect(callApi()).resolves.toBe("Texto interno");
+  });
+
+  it("extrai texto de objetos com texto", async () => {
+    postMock.mockResolvedValue({ data: { resposta: { texto: "Texto em português" } }, status: 200 });
+
+    await expect(callApi()).resolves.toBe("Texto em português");
+  });
+
+  it("concatena itens de arrays quando necessário", async () => {
+    postMock.mockResolvedValue({ data: { message: ["Parte 1", "Parte 2"] }, status: 200 });
+
+    await expect(callApi()).resolves.toBe("Parte 1\n\nParte 2");
+  });
+
+  it("extrai texto de estruturas compatíveis com OpenAI", async () => {
+    postMock.mockResolvedValue({
+      data: {
+        choices: [
+          {
+            message: {
+              content: "Resposta da assistente",
+            },
+          },
+        ],
+      },
+      status: 200,
+    });
+
+    await expect(callApi()).resolves.toBe("Resposta da assistente");
+  });
+
+  it("lança erro quando não há conteúdo textual", async () => {
+    postMock.mockResolvedValue({ data: { vazio: true }, status: 200 });
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(callApi()).rejects.toThrow("Formato inválido na resposta da Eco.");
+
+    errorSpy.mockRestore();
+  });
+});
+

--- a/src/api/ecoApi.ts
+++ b/src/api/ecoApi.ts
@@ -8,9 +8,93 @@ interface Message {
   content: string;
 }
 
-type AskEcoResponse =
-  | { message?: string; resposta?: string; data?: { message?: string; resposta?: string } }
-  | any;
+type AskEcoTextValue =
+  | string
+  | AskEcoTextValue[]
+  | {
+      content?: AskEcoTextValue;
+      texto?: AskEcoTextValue;
+      text?: AskEcoTextValue;
+    };
+
+interface AskEcoChoiceMessage {
+  content?: AskEcoTextValue;
+  texto?: AskEcoTextValue;
+}
+
+interface AskEcoChoice {
+  message?: AskEcoChoiceMessage;
+  delta?: AskEcoChoiceMessage;
+  text?: AskEcoTextValue;
+}
+
+type AskEcoPayload =
+  | AskEcoTextValue
+  | {
+      message?: AskEcoPayload;
+      resposta?: AskEcoPayload;
+      mensagem?: AskEcoPayload;
+      data?: AskEcoPayload;
+      choices?: AskEcoChoice[];
+    };
+
+type AskEcoResponse = AskEcoPayload;
+
+const isDev = Boolean((import.meta as any)?.env?.DEV);
+
+const TEXTUAL_KEYS = ["content", "texto", "text"] as const;
+const NESTED_KEYS = ["message", "resposta", "mensagem", "data", "value", "delta"] as const;
+
+const collectTexts = (value: unknown, visited = new WeakSet<object>()): string[] => {
+  if (typeof value === "string") return [value];
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectTexts(item, visited));
+  }
+
+  if (value && typeof value === "object") {
+    if (visited.has(value as object)) return [];
+    visited.add(value as object);
+
+    const obj = value as Record<string, unknown> & { choices?: unknown };
+    const results: string[] = [];
+
+    TEXTUAL_KEYS.forEach((key) => {
+      if (key in obj) {
+        results.push(...collectTexts(obj[key], visited));
+      }
+    });
+
+    NESTED_KEYS.forEach((key) => {
+      if (key in obj) {
+        results.push(...collectTexts(obj[key], visited));
+      }
+    });
+
+    if (Array.isArray(obj.choices)) {
+      results.push(...obj.choices.flatMap((choice) => collectTexts(choice, visited)));
+    }
+
+    return results;
+  }
+
+  return [];
+};
+
+const normalizeAskEcoResponse = (payload: AskEcoResponse): string | undefined => {
+  const texts = collectTexts(payload);
+  const unique = Array.from(
+    new Set(
+      texts
+        .map((text) => text.trim())
+        .filter((text) => text.length > 0)
+    )
+  );
+
+  if (unique.length === 0) return undefined;
+
+  return unique.join("\n\n");
+};
 
 export const enviarMensagemParaEco = async (
   userMessages: Message[],
@@ -41,10 +125,13 @@ export const enviarMensagemParaEco = async (
 
     if (status < 200 || status >= 300) throw new Error("Erro inesperado da API /ask-eco");
 
-    const texto =
-      data?.message ?? data?.resposta ?? data?.data?.message ?? data?.data?.resposta;
+    const texto = normalizeAskEcoResponse(data);
 
     if (typeof texto === "string") return texto;
+
+    if (isDev) {
+      console.warn("⚠️ [ECO API] Resposta inesperada:", data);
+    }
 
     throw new Error("Formato inválido na resposta da Eco.");
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- normalize AskEcoResponse handling to support nested message/resposta objects and OpenAI-style choices
- warn in development about unexpected payloads before surfacing Eco format errors
- add Vitest coverage to ensure diverse backend payloads produce assistant text

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68dd5699dfc88325811d71577b9e1df5