### PR TITLE
Implement streaming Eco API client

### DIFF
--- a/src/api/ecoApi.ts
+++ b/src/api/ecoApi.ts
@@ -1,5 +1,6 @@
 // src/api/ecoApi.ts
 import api from "./axios";
+import { supabase } from "../lib/supabaseClient";
 import { v4 as uuidv4 } from "uuid";
 
 interface Message {
@@ -40,7 +41,14 @@ type AskEcoPayload =
 
 type AskEcoResponse = AskEcoPayload;
 
+export interface EcoStreamResult {
+  text: string;
+  metadata?: unknown;
+  done?: unknown;
+}
+
 const isDev = Boolean((import.meta as any)?.env?.DEV);
+const SSE_TIMEOUT_MS = 60_000;
 
 const TEXTUAL_KEYS = ["content", "texto", "text"] as const;
 const NESTED_KEYS = ["message", "resposta", "mensagem", "data", "value", "delta"] as const;
@@ -81,6 +89,30 @@ const collectTexts = (value: unknown, visited = new WeakSet<object>()): string[]
   return [];
 };
 
+const parseSseEvent = (eventBlock: string): unknown | undefined => {
+  const lines = eventBlock
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith(":"));
+
+  if (lines.length === 0) return undefined;
+
+  const payload = lines
+    .map((line) => (line.startsWith("data:") ? line.slice(5).trimStart() : line))
+    .join("\n");
+
+  if (!payload) return undefined;
+
+  try {
+    return JSON.parse(payload);
+  } catch (error) {
+    if (isDev) {
+      console.warn("⚠️ [ECO API] Evento SSE inválido:", payload, error);
+    }
+    return undefined;
+  }
+};
+
 const normalizeAskEcoResponse = (payload: AskEcoResponse): string | undefined => {
   const texts = collectTexts(payload);
   const unique = Array.from(
@@ -102,7 +134,7 @@ export const enviarMensagemParaEco = async (
   userId?: string,
   clientHour?: number,
   clientTz?: string
-): Promise<string> => {
+): Promise<EcoStreamResult> => {
   const mensagensValidas: Message[] = userMessages
     .slice(-3)
     .filter((m) => m && typeof m.role === "string" && typeof m.content === "string" && m.content.trim().length > 0)
@@ -113,35 +145,185 @@ export const enviarMensagemParaEco = async (
   const hour = typeof clientHour === "number" ? clientHour : new Date().getHours();
   const tz = clientTz || Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+  const controller = new AbortController();
+  const timeoutId: ReturnType<typeof setTimeout> = setTimeout(() => {
+    controller.abort();
+  }, SSE_TIMEOUT_MS);
+
   try {
-    // 👇 sem /api aqui!
-    const { data, status } = await api.post<AskEcoResponse>("/ask-eco", {
-      mensagens: mensagensValidas,      // o backend normaliza (messages | mensagens | mensagem)
-      nome_usuario: userName,
-      usuario_id: userId,
-      clientHour: hour,
-      clientTz: tz,
+    const baseUrl = api.defaults?.baseURL?.replace(/\/+$/, "");
+    if (!baseUrl) throw new Error("Configuração de baseURL ausente para a Eco.");
+
+    const { data: sessionData } = await supabase.auth.getSession();
+    const token = sessionData.session?.access_token;
+
+    const response = await fetch(`${baseUrl}/ask-eco`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      credentials: "include",
+      body: JSON.stringify({
+        mensagens: mensagensValidas,
+        nome_usuario: userName,
+        usuario_id: userId,
+        clientHour: hour,
+        clientTz: tz,
+      }),
+      signal: controller.signal,
     });
 
-    if (status < 200 || status >= 300) throw new Error("Erro inesperado da API /ask-eco");
+    if (!response.ok) {
+      let serverErr: string | undefined;
+      const contentType = response.headers.get("content-type") || "";
+      try {
+        if (contentType.includes("application/json")) {
+          const errJson = await response.json();
+          serverErr = errJson?.error || errJson?.message;
+        } else {
+          serverErr = await response.text();
+        }
+      } catch {
+        // ignora falhas ao ler corpo de erro
+      }
 
-    const texto = normalizeAskEcoResponse(data);
-
-    if (typeof texto === "string") return texto;
-
-    if (isDev) {
-      console.warn("⚠️ [ECO API] Resposta inesperada:", data);
+      const msg =
+        (serverErr && typeof serverErr === "string" && serverErr.trim()) ||
+        `Erro HTTP ${response.status}: ${response.statusText || "Falha na requisição"}`;
+      throw new Error(msg);
     }
 
-    throw new Error("Formato inválido na resposta da Eco.");
+    if (!response.body) {
+      throw new Error("Resposta da Eco não suportou streaming SSE.");
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let doneReceived = false;
+    let streamError: Error | null = null;
+    const aggregatedParts: string[] = [];
+    let donePayload: unknown;
+    let metadata: unknown;
+
+    const handleEvent = (eventData: unknown) => {
+      if (!eventData || typeof eventData !== "object") return;
+
+      const baseEvent = eventData as Record<string, any>;
+      const topType = typeof baseEvent.type === "string" ? baseEvent.type : undefined;
+      const eventPayloadRaw = baseEvent.payload && typeof baseEvent.payload === "object" ? baseEvent.payload : baseEvent;
+      const payload = eventPayloadRaw as Record<string, any>;
+      const payloadType = typeof payload.type === "string" ? payload.type : topType;
+
+      if (payloadType === "chunk") {
+        const source = payload.delta ?? payload.content ?? payload.message ?? payload;
+        const texts = collectTexts(source);
+        if (texts.length > 0) {
+          aggregatedParts.push(texts.join(""));
+        }
+        return;
+      }
+
+      if (payloadType === "done") {
+        doneReceived = true;
+        donePayload = payload;
+        metadata = payload?.response ?? payload?.metadata ?? payload;
+        return;
+      }
+
+      if (payloadType === "error" || payload?.status === "error") {
+        const errMessage =
+          payload?.error?.message ||
+          payload?.error ||
+          payload?.message ||
+          "Erro na stream SSE da Eco.";
+        streamError = new Error(String(errMessage));
+        return;
+      }
+
+      if (isDev) {
+        console.debug("ℹ️ [ECO API] Evento SSE ignorado:", eventData);
+      }
+    };
+
+    const flushBuffer = (final = false) => {
+      let separatorIndex = buffer.indexOf("\n\n");
+      while (separatorIndex !== -1) {
+        const segment = buffer.slice(0, separatorIndex);
+        buffer = buffer.slice(separatorIndex + 2);
+        const parsed = parseSseEvent(segment);
+        if (parsed !== undefined) {
+          handleEvent(parsed);
+        }
+        separatorIndex = buffer.indexOf("\n\n");
+      }
+
+      if (final) {
+        const remainder = buffer.trim();
+        if (remainder.length > 0) {
+          const parsed = parseSseEvent(buffer);
+          if (parsed !== undefined) {
+            handleEvent(parsed);
+          }
+        }
+        buffer = "";
+      }
+    };
+
+    while (!doneReceived && !streamError) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      flushBuffer();
+    }
+
+    if (!streamError) {
+      buffer += decoder.decode();
+      flushBuffer(true);
+    }
+
+    if (streamError) throw streamError;
+
+    if (!doneReceived) {
+      throw new Error('Fluxo SSE encerrado sem evento "done".');
+    }
+
+    let texto = aggregatedParts.join("").trim();
+
+    if (!texto && donePayload) {
+      const fallback = normalizeAskEcoResponse(donePayload as AskEcoResponse);
+      if (fallback) texto = fallback;
+    }
+
+    if (!texto) {
+      if (isDev) {
+        console.warn("⚠️ [ECO API] Resposta SSE sem conteúdo textual:", donePayload);
+      }
+      throw new Error("Formato inválido na resposta da Eco.");
+    }
+
+    return { text: texto, metadata, done: donePayload };
   } catch (error: any) {
-    const status = error?.response?.status;
-    const serverErr = error?.response?.data?.error || error?.response?.data?.message;
-    const msg =
-      serverErr ||
-      (status ? `Erro HTTP ${status}: ${error?.response?.statusText || "Falha na requisição"}` : "") ||
-      (error?.message ?? "Erro ao obter resposta da Eco.");
-    console.error("❌ [ECO API] Erro ao enviar mensagem:", msg);
-    throw new Error(msg);
+    let message: string;
+
+    if (error?.name === "AbortError") {
+      message = "A requisição à Eco expirou. Tente novamente.";
+    } else if (typeof error?.message === "string" && error.message.trim().length > 0) {
+      message = error.message;
+    } else {
+      message = "Erro ao obter resposta da Eco.";
+    }
+
+    if (isDev) {
+      console.error("❌ [ECO API] Erro ao enviar mensagem:", message, error);
+    } else {
+      console.error("❌ [ECO API] Erro ao enviar mensagem:", message);
+    }
+
+    throw new Error(message);
+  } finally {
+    clearTimeout(timeoutId);
   }
 };


### PR DESCRIPTION
## Summary
- replace the axios-based /ask-eco call with a streaming fetch client that parses SSE chunks and collects assistant text
- adapt the chat page to consume the new text/metadata response and avoid appending technical JSON to the UI
- rewrite the ecoApi unit tests to cover SSE flows and error conditions

## Testing
- npm run test -- --run src/api/__tests__/ecoApi.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd62d20fc483259a345415ff65d49c