### PR TITLE
Trigger celebration when first memory flag is returned

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -24,6 +24,7 @@ import { salvarMensagem } from '../api/mensagem';
 
 import { differenceInDays } from 'date-fns';
 import { extrairTagsRelevantes } from '../utils/extrairTagsRelevantes';
+import celebrateFirstMemory from '../utils/celebrateFirstMemory';
 import mixpanel from '../lib/mixpanel';
 
 import { FeedbackPrompt } from '../components/FeedbackPrompt';
@@ -394,6 +395,10 @@ const ChatPage: React.FC = () => {
         clientHour,
         clientTz
       );
+
+      if (resposta?.primeiraMemoriaSignificativa) {
+        celebrateFirstMemory();
+      }
 
       const textoEco = (resposta?.text || '').trim();
       const bloco =


### PR DESCRIPTION
## Summary
- import the celebrateFirstMemory helper into ChatPage
- fire the celebration when enviarMensagemParaEco reports primeiraMemoriaSignificativa

## Testing
- npm run lint *(fails due to pre-existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68de9a2d5bec8325a69b779ce7e6662e