### PR TITLE
feat: stream eco responses incrementally

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -19,6 +19,10 @@ export interface Message {
   sender: 'user' | 'eco';
   role?: 'user' | 'assistant' | 'system';
   deepQuestion?: boolean;
+  metadata?: unknown;
+  memory?: unknown;
+  donePayload?: unknown;
+  latencyMs?: number;
 }
 
 interface ChatContextType {


### PR DESCRIPTION
## Summary
- add streaming event handlers to `enviarMensagemParaEco` so callers can react to each SSE payload as it arrives
- update the chat page to create and update Eco replies in real time while recording metadata, latency and memory events
- extend the Eco API tests and chat message type definitions to cover the incremental callback flow

## Testing
- npm run test -- ecoApi

------
https://chatgpt.com/codex/tasks/task_e_68e2cb3e18c883259936284bc1a5d337