### PR TITLE
Refine typing dots blue theme

### DIFF
--- a/src/components/TypingDots.tsx
+++ b/src/components/TypingDots.tsx
@@ -3,17 +3,20 @@ import React from "react";
 import { motion } from "framer-motion";
 
 type Variant = "pill" | "bubble" | "inline";
+type Tone = "auto" | "light" | "dark";
+
 type Props = {
   variant?: Variant;
   size?: "sm" | "md" | "lg";
   className?: string;
+  tone?: Tone;
 };
 
 const SIZES = {
   sm: { dot: 7, gap: 8, padX: 10, padY: 7, radius: "rounded-xl" },
   md: { dot: 9, gap: 11, padX: 14, padY: 9, radius: "rounded-2xl" },
   lg: { dot: 11, gap: 14, padX: 18, padY: 11, radius: "rounded-3xl" },
-};
+} as const;
 
 const dotTransition = {
   repeat: Infinity,
@@ -21,12 +24,68 @@ const dotTransition = {
   duration: 1.2,
 };
 
+const toneTokens = {
+  light: {
+    dot: "rgba(0, 122, 255, 0.85)",
+    dotDim: "rgba(27, 79, 255, 0.55)",
+    container: "rgba(0, 122, 255, 0.14)",
+    bubble: "rgba(0, 122, 255, 0.18)",
+    border: "rgba(0, 122, 255, 0.36)",
+    halo: "rgba(0, 122, 255, 0.18)",
+    shadow: "0 4px 10px rgba(0, 76, 167, 0.14)",
+  },
+  dark: {
+    dot: "rgba(118, 160, 255, 0.94)",
+    dotDim: "rgba(91, 153, 255, 0.72)",
+    container: "rgba(27, 79, 255, 0.22)",
+    bubble: "rgba(27, 79, 255, 0.27)",
+    border: "rgba(118, 160, 255, 0.42)",
+    halo: "rgba(27, 79, 255, 0.26)",
+    shadow: "0 4px 12px rgba(4, 20, 70, 0.32)",
+  },
+} as const;
+
+const explicitTone = (tone: Exclude<Tone, "auto">): "light" | "dark" =>
+  tone === "dark" ? "dark" : "light";
+
 const TypingDots: React.FC<Props> = ({
   variant = "pill",
   size = "md",
   className = "",
+  tone = "auto",
 }) => {
+  const [resolvedTone, setResolvedTone] = React.useState<"light" | "dark">(
+    tone === "auto" ? "light" : explicitTone(tone)
+  );
+
+  React.useEffect(() => {
+    if (tone === "auto") {
+      if (typeof window === "undefined" || !window.matchMedia) {
+        setResolvedTone("light");
+        return;
+      }
+
+      const media = window.matchMedia("(prefers-color-scheme: dark)");
+      const handleChange = (event: MediaQueryListEvent) => {
+        setResolvedTone(event.matches ? "dark" : "light");
+      };
+
+      setResolvedTone(media.matches ? "dark" : "light");
+
+      if (typeof media.addEventListener === "function") {
+        media.addEventListener("change", handleChange);
+        return () => media.removeEventListener("change", handleChange);
+      }
+
+      media.addListener(handleChange);
+      return () => media.removeListener(handleChange);
+    }
+
+    setResolvedTone(explicitTone(tone));
+  }, [tone]);
+
   const s = SIZES[size];
+  const tokens = toneTokens[resolvedTone];
 
   const baseDots = (
     <>
@@ -34,9 +93,16 @@ const TypingDots: React.FC<Props> = ({
         <motion.span
           key={i}
           role="presentation"
-          className="inline-block rounded-full bg-slate-400/70 dark:bg-slate-300/70"
-          style={{ width: s.dot, height: s.dot }}
-          animate={{ y: [0, -3, 0], opacity: [0.68, 1, 0.68] }}
+          className="inline-block rounded-full"
+          style={{
+            width: s.dot,
+            height: s.dot,
+            backgroundColor: tokens.dotDim,
+          }}
+          animate={{
+            y: [0, -3, 0],
+            backgroundColor: [tokens.dotDim, tokens.dot, tokens.dotDim],
+          }}
           transition={{ ...dotTransition, delay }}
         />
       ))}
@@ -49,21 +115,13 @@ const TypingDots: React.FC<Props> = ({
       inline-flex items-center
       px-[${s.padX}px] py-[${s.padY}px] ${s.radius}
       gap-[${s.gap}px]
-      bg-white/65 dark:bg-white/10
-      backdrop-blur-md
-      border border-white/40 dark:border-white/15
-      shadow-[inset_0_1px_0_rgba(255,255,255,0.6),0_8px_24px_rgba(0,0,0,0.06)]
+      border
     `,
     bubble: `
       inline-flex items-center
       px-[${s.padX}px] py-[${s.padY}px] rounded-full
       gap-[${s.gap}px]
-      bg-[radial-gradient(120%_120%_at_30%_30%,rgba(255,255,255,0.9),rgba(255,255,255,0.55))]
-      dark:bg-[radial-gradient(120%_120%_at_30%_30%,rgba(255,255,255,0.15),rgba(255,255,255,0.06))]
-      backdrop-blur-xl
-      border border-white/50 dark:border-white/10
-      shadow-[0_10px_30px_rgba(0,0,0,0.08)]
-      ring-1 ring-black/5
+      border
     `,
     inline: `
       inline-flex items-center gap-[${s.gap}px]
@@ -71,19 +129,30 @@ const TypingDots: React.FC<Props> = ({
     `,
   };
 
+  const containerStyle =
+    variant === "inline"
+      ? undefined
+      : {
+          backgroundColor:
+            variant === "bubble" ? tokens.bubble : tokens.container,
+          borderColor: tokens.border,
+          boxShadow: tokens.shadow,
+        };
+
   // Halo suave (apenas para pill e bubble)
   const Halo = () =>
     variant === "inline" ? null : (
       <span
         aria-hidden
-        className="absolute inset-0 -z-10 rounded-[inherit] blur-xl opacity-50
-                   bg-[radial-gradient(60%_60%_at_50%_10%,#EEF2FF,transparent_70%)] dark:opacity-20"
+        className="absolute inset-0 -z-10 rounded-[inherit]"
+        style={{ backgroundColor: tokens.halo }}
       />
     );
 
   return (
     <div
       className={`relative ${containers[variant]} ${className}`}
+      style={containerStyle}
       aria-live="polite"
       aria-label="Eco está digitando"
       role="status"


### PR DESCRIPTION
## Summary
- switch typing indicator dots to a translucent #007AFF / #1B4FFF palette and animate their color instead of opacity
- simplify the pill and bubble containers with soft blue backgrounds and lighter halos while keeping rounded geometry
- expose a `tone` prop that can follow system color scheme or force light/dark rendering of the new palette

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f6c18fcc8325911104282441d006