### PR TITLE
feat: refresh chat bubble styling

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -45,13 +45,18 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ message, isEcoTyping }) => {
   ].join(" ");
 
   const bubbleStyle: React.CSSProperties = {
-    backgroundColor: isUser ? "#F5F7FA" : "#007AFF",
-    color: isUser ? "#0F172A" : "#FFFFFF",
-    borderColor: isUser ? "#E2E8F0" : "#0064DA",
-    borderRadius: 20,
+    backgroundColor: isUser ? "#007AFF" : "#F3F4F6",
+    color: isUser ? "#FFFFFF" : "#0F172A",
+    borderColor: isUser ? "#0064D2" : "#D0D5DD",
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    borderBottomLeftRadius: isUser ? 20 : 12,
+    borderBottomRightRadius: isUser ? 12 : 20,
     boxShadow: isUser
-      ? "0 8px 20px rgba(15, 23, 42, 0.08)"
-      : "0 12px 28px rgba(0, 122, 255, 0.28)",
+      ? "0 4px 10px rgba(0, 98, 204, 0.28)"
+      : "0 3px 9px rgba(15, 23, 42, 0.12)",
+    backdropFilter: "none",
+    WebkitBackdropFilter: "none",
   };
 
   const markdownClassName = [
@@ -62,7 +67,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ message, isEcoTyping }) => {
     "prose-a:underline prose-a:break-words",
     "prose-pre:bg-gray-50/70 prose-pre:border prose-pre:border-gray-200/60 prose-pre:rounded-xl prose-pre:p-3",
     "prose-code:before:content-[''] prose-code:after:content-['']",
-    !isUser ? "prose-invert" : "",
+    isUser ? "prose-invert" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -97,7 +102,9 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ message, isEcoTyping }) => {
                 <div className={markdownClassName}>
                   <ReactMarkdown
                     components={{
-                      p: ({ node, ...props }) => <p className="m-0 mb-2 last:mb-0" {...props} />,
+                      p: ({ node: _node, ...props }) => (
+                        <p className="m-0 mb-2 last:mb-0" {...props} />
+                      ),
                     }}
                   >
                     {text}

--- a/src/components/EcoMessageWithAudio.tsx
+++ b/src/components/EcoMessageWithAudio.tsx
@@ -78,10 +78,10 @@ const EcoMessageWithAudio: React.FC<EcoMessageWithAudioProps> = ({
     </button>
   );
 
-  // padding lateral da barra de ações acompanha a bolha:
-  // - user (direita): um pequeno recuo à direita para não “colar” na borda
-  // - eco (esquerda): recuo para alinhar com o começo do texto (considerando a bolha com 16px internos)
-  const actionsPad = isUser ? "mr-2" : "ml-[42px] sm:ml-[50px]";
+  // padding/margem da barra acompanha a bolha:
+  // - user (direita): padding à direita espelha o padding interno da bolha
+  // - eco (esquerda): margem soma avatar (30px), gap (12px) e padding interno
+  const actionsPad = isUser ? "pr-4 sm:pr-5" : "ml-[58px] sm:ml-[62px]";
 
   return (
     <>
@@ -96,7 +96,10 @@ const EcoMessageWithAudio: React.FC<EcoMessageWithAudioProps> = ({
               "mt-1 flex items-center gap-1.5",
               "max-w-[min(720px,88vw)] min-w-0", // acompanha o mesmo limite da bolha
               actionsPad,
-            ].join(" ")}
+              isUser ? "self-end" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
           >
             <GhostBtn onClick={copiarTexto} aria-label="Copiar mensagem" title="Copiar">
               <ClipboardCopy className={ICON_CLASS} strokeWidth={1.5} />

--- a/src/index.css
+++ b/src/index.css
@@ -47,11 +47,11 @@ body {
   --glass-border: rgba(0,0,0,0.06);
   --glass-shadow: 0 8px 24px rgba(0,0,0,0.08);
 
-  /* bolhas (user agora neutra, sem verde) */
-  --bubble-eco-bg:  rgba(255,255,255,0.60);
-  --bubble-user-bg: rgba(255,255,255,0.55);
-  --bubble-border:  rgba(15,23,42,0.10);
-  --bubble-shadow:  0 3px 10px rgba(15,23,42,0.06);
+  /* bolhas (paleta sólida minimalista) */
+  --bubble-eco-bg:  #f3f4f6;
+  --bubble-user-bg: #007aff;
+  --bubble-border:  rgba(15,23,42,0.12);
+  --bubble-shadow:  0 3px 9px rgba(15,23,42,0.12);
 }
 
 /* Dark pronto (opcional) */
@@ -61,21 +61,40 @@ body {
     --glass-bg: rgba(18,22,34,.35);
     --glass-bg-strong: rgba(18,22,34,.55);
     --glass-border: rgba(255,255,255,.08);
-    --bubble-eco-bg: rgba(255,255,255,.10);
-    --bubble-user-bg: rgba(255,255,255,.08);
-    --bubble-border: rgba(255,255,255,.10);
+    --bubble-eco-bg: rgba(30,41,59,.85);
+    --bubble-user-bg: #3b82f6;
+    --bubble-border: rgba(148,163,184,.28);
   }
   body { background-color: var(--bg-cream); color: #e5e7eb; }
 }
 
 /* Alto contraste / menos transparência */
 @media (prefers-contrast: more) {
-  .glass, .glass-strong, .glass-panel,
-  .message-bubble {
+  .glass, .glass-strong, .glass-panel {
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
     background: #ffffff !important;
     border-color: rgba(0,0,0,.18) !important;
+  }
+
+  .message-bubble {
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
+
+  .message-bubble[data-sender="user"] {
+    background: var(--bubble-user-bg) !important;
+    color: #ffffff !important;
+    border-color: #0056c8 !important;
+    box-shadow: 0 4px 10px rgba(0, 86, 200, 0.32) !important;
+  }
+
+  .message-bubble[data-sender="eco"],
+  .message-bubble:not([data-sender]) {
+    background: var(--bubble-eco-bg) !important;
+    color: #0f172a !important;
+    border-color: var(--bubble-border) !important;
+    box-shadow: var(--bubble-shadow) !important;
   }
 }
 
@@ -197,13 +216,32 @@ html, body, #root { height: 100%; min-height: 0; }
 
 @supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
   .glass, .glass-strong, .glass-panel, .glass-button, .glass-popover,
-  .tint-teal, .tint-violet, .tint-gray,
-  .message-bubble {
+  .tint-teal, .tint-violet, .tint-gray {
     background: rgba(255,255,255,0.92) !important;
     border-color: rgba(0,0,0,0.06) !important;
     box-shadow: 0 6px 16px rgba(0,0,0,0.06) !important;
     -webkit-backdrop-filter: none !important;
     backdrop-filter: none !important;
+  }
+
+  .message-bubble {
+    -webkit-backdrop-filter: none !important;
+    backdrop-filter: none !important;
+  }
+
+  .message-bubble[data-sender="user"] {
+    background: var(--bubble-user-bg) !important;
+    color: #ffffff !important;
+    border-color: #0064d2 !important;
+    box-shadow: 0 4px 10px rgba(0, 98, 204, 0.28) !important;
+  }
+
+  .message-bubble[data-sender="eco"],
+  .message-bubble:not([data-sender]) {
+    background: var(--bubble-eco-bg) !important;
+    color: #0f172a !important;
+    border-color: var(--bubble-border) !important;
+    box-shadow: var(--bubble-shadow) !important;
   }
 }
 
@@ -387,14 +425,14 @@ body.keyboard-open { overscroll-behavior-y: contain; padding-bottom: var(--safe-
   .glass { backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); }
   .glass-strong { backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); }
   .message-bubble {
-    -webkit-backdrop-filter: saturate(1.1) blur(12px);
-    backdrop-filter: saturate(1.1) blur(12px);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
   }
 }
 
 /* Em telas com pointer “coarse” (toque), suavize blur */
 @media (pointer: coarse) and (hover: none) {
-  .glass, .glass-strong, .message-bubble {
+  .glass, .glass-strong {
     -webkit-backdrop-filter: blur(10px);
     backdrop-filter: blur(10px);
   }


### PR DESCRIPTION
## Summary
- update chat bubble styling to use a solid user blue and light eco gray with inverted markdown where appropriate
- flatten bubble shadows/backdrops, tweak corner radii, and realign the Eco action bar for the new geometry
- refresh global bubble tokens and fallbacks so other consumers inherit the solid palette in normal, contrast, and no-backdrop modes

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ff149d2c8325ba15b97678427110