### PR TITLE
Fix TypingDots transition syntax error

### DIFF
--- a/src/components/TypingDots.tsx
+++ b/src/components/TypingDots.tsx
@@ -108,10 +108,11 @@ const TypingDots: React.FC<Props> = ({
                   backgroundColor: [tokens.dotDim, tokens.dot, tokens.dotDim],
                 }
           }
-          transition=
+          transition={
             dotTransition && delay
               ? { ...dotTransition, delay }
               : dotTransition || undefined
+          }
         />
       ))}
     </>


### PR DESCRIPTION
## Summary
- wrap the TypingDots transition prop in braces to restore valid JSX syntax
- ensure animated dots continue to respect reduced motion settings without breaking the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2f1f8f11c83259cc809cc361ead2a