### PR TITLE
Improve typing indicator handling during streaming

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -9,11 +9,21 @@ interface ChatMessageProps {
   isEcoTyping?: boolean;
 }
 
+const extractMessageText = (message: Message) => {
+  if (typeof message.text === "string") return message.text;
+  if (typeof message.content === "string") return message.content;
+  return "";
+};
+
 const ChatMessage: React.FC<ChatMessageProps> = ({ message, isEcoTyping }) => {
   const isUser = message.sender === "user";
-  const showTyping = !!isEcoTyping && !isUser;
+  const rawText = extractMessageText(message);
+  const trimmedText = rawText.trim();
 
-  const text = showTyping ? "" : String(message.text ?? message.content ?? "").trim();
+  const isStreamingPlaceholder = !isUser && trimmedText.length === 0;
+  const showTyping = !isUser && (Boolean(isEcoTyping) || isStreamingPlaceholder);
+
+  const text = showTyping ? "" : trimmedText;
 
   if (showTyping) {
     return (

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -867,6 +867,15 @@ const ChatPage: React.FC = () => {
     await handleSendMessage(userText, hint);
   };
 
+  const lastMessage = messages[messages.length - 1];
+  const lastEcoMessageIsPlaceholder =
+    !!lastMessage &&
+    lastMessage.sender === 'eco' &&
+    ((typeof lastMessage.text === 'string' && lastMessage.text.trim().length === 0)
+      || (typeof lastMessage.content === 'string' && lastMessage.content.trim().length === 0));
+
+  const shouldShowGlobalTyping = digitando && !lastEcoMessageIsPlaceholder;
+
   return (
     <div className="relative flex h-[calc(100dvh-var(--eco-topbar-h,56px))] w-full flex-col overflow-hidden bg-white">
       {/* SCROLLER */}
@@ -933,7 +942,7 @@ const ChatPage: React.FC = () => {
               </div>
             )}
 
-            {digitando && (
+            {shouldShowGlobalTyping && (
               <div className="w-full flex justify-start">
                 <div className="max-w-3xl w-full min-w-0 flex items-start gap-3">
                   <div className="flex-shrink-0 translate-y-[2px]">

--- a/src/pages/__tests__/ChatPage.typingIndicator.test.tsx
+++ b/src/pages/__tests__/ChatPage.typingIndicator.test.tsx
@@ -50,15 +50,27 @@ vi.mock('../../contexts/ChatContext', () => {
 });
 
 vi.mock('../../components/ChatMessage', () => ({
-  default: ({ message }: { message: any }) => (
-    <div data-testid={`chat-${message.id}`}>{message.text}</div>
-  ),
+  default: ({ message }: { message: any }) => {
+    const text = typeof message.text === 'string' ? message.text : '';
+    const trimmed = text.trim();
+    return (
+      <div data-testid={`chat-${message.id}`}>
+        {trimmed.length > 0 ? text : <div data-testid="typing-dots">digitando…</div>}
+      </div>
+    );
+  },
 }));
 
 vi.mock('../../components/EcoMessageWithAudio', () => ({
-  default: ({ message }: { message: any }) => (
-    <div data-testid={`eco-${message.id}`}>{message.text}</div>
-  ),
+  default: ({ message }: { message: any }) => {
+    const text = typeof message.text === 'string' ? message.text : '';
+    const trimmed = text.trim();
+    return (
+      <div data-testid={`eco-${message.id}`}>
+        {trimmed.length > 0 ? text : <div data-testid="typing-dots">digitando…</div>}
+      </div>
+    );
+  },
 }));
 
 vi.mock('../../components/QuickSuggestions', () => ({


### PR DESCRIPTION
## Summary
- ensure ChatMessage renders the animated typing indicator whenever Eco's streamed message only has placeholder whitespace
- avoid showing the global "digitando" row when the latest Eco message is already acting as the typing placeholder
- adjust the typing indicator unit test mocks so they mirror the new placeholder behaviour during streaming

## Testing
- npm run test -- ChatPage.typingIndicator.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e308ea89e08325810238c9ba08ae70