### PR TITLE
Fix guest chat CORS by proxying API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,11 +79,9 @@ function AppInner() {
         <Route
           path="/chat"
           element={
-            <ProtectedRoute>
-              <MainLayout>
-                <ChatPage />
-              </MainLayout>
-            </ProtectedRoute>
+            <MainLayout>
+              <ChatPage />
+            </MainLayout>
           }
         />
 

--- a/src/api/__tests__/ecoApi.test.ts
+++ b/src/api/__tests__/ecoApi.test.ts
@@ -208,6 +208,31 @@ describe("enviarMensagemParaEco", () => {
     expect(resposta.metadata).toEqual({ intensidade: 9 });
     expect(resposta.primeiraMemoriaSignificativa).toBe(true);
   });
+
+  it("inclui cabeçalho e payload de convidado quando isGuest é informado", async () => {
+    fetchMock.mockResolvedValue(
+      createSseResponse([
+        { type: "done", payload: { type: "done", message: { content: "oi" } } },
+      ])
+    );
+
+    await enviarMensagemParaEco(
+      mensagens,
+      "Convidado",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { guestId: "guest-123", isGuest: true }
+    );
+
+    const [, init] = fetchMock.mock.calls.at(-1) ?? [];
+    expect(init?.headers).toMatchObject({ "x-guest-id": "guest-123" });
+    const body = init?.body ? JSON.parse(init.body as string) : {};
+    expect(body.isGuest).toBe(true);
+    expect(body.guestId).toBe("guest-123");
+    expect(body.usuario_id).toBeUndefined();
+  });
 });
 
 afterAll(() => {

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,13 +2,13 @@
 import axios from "axios";
 import { supabase } from "../lib/supabaseClient"; // ajuste o path se preciso
 
-const API_BASE =
-  import.meta.env.VITE_API_BASE?.replace(/\/+$/, "") ||
-  "https://ecobackend888.onrender.com";
+const envBase = import.meta.env.VITE_API_BASE;
+const normalizedBase = typeof envBase === "string" ? envBase.replace(/\/+$/, "") : "";
 
-// baseURL termina em /api
+const baseURL = normalizedBase ? `${normalizedBase}/api` : "/api";
+
 const api = axios.create({
-  baseURL: `${API_BASE}/api`,
+  baseURL,
   headers: { "Content-Type": "application/json" },
   withCredentials: true,
 });

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -8,6 +8,7 @@ type Props = {
   onSendAudio?: (b: Blob) => void;
   disabled?: boolean;
   onTextChange?: (text: string) => void;
+  placeholder?: string;
 };
 
 const CTA_TEXT = 'Converse com a Eco…';
@@ -18,6 +19,7 @@ const ChatInput: React.FC<Props> = ({
   onSendAudio,
   disabled = false,
   onTextChange,
+  placeholder = CTA_TEXT,
 }) => {
   const [inputMessage, setInputMessage] = useState('');
   const [showMoreOptions, setShowMoreOptions] = useState(false);
@@ -313,7 +315,7 @@ const ChatInput: React.FC<Props> = ({
             }}
             onFocus={onFocus}
             onBlur={onBlur}
-            placeholder={CTA_TEXT}
+            placeholder={placeholder}
             rows={1}
             inputMode="text"
             enterKeyHint="send"

--- a/src/components/LoginGateModal.tsx
+++ b/src/components/LoginGateModal.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+interface LoginGateModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSignup: () => void;
+  count: number;
+  limit: number;
+}
+
+const LoginGateModal: React.FC<LoginGateModalProps> = ({ open, onClose, onSignup, count, limit }) => {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+        <h2 className="text-xl font-semibold text-slate-900">Crie sua conta para continuar</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Você alcançou {count}/{limit} interações gratuitas. Entre ou cadastre-se para continuar a conversa e salvar seu progresso.
+        </p>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+          <button
+            onClick={onSignup}
+            className="rounded-xl bg-black px-4 py-2 text-center text-white transition hover:opacity-90"
+          >
+            Criar conta / Entrar
+          </button>
+          <button
+            onClick={onClose}
+            className="rounded-xl border border-slate-200 px-4 py-2 text-center font-medium text-slate-700 transition hover:bg-slate-50"
+          >
+            Agora não
+          </button>
+        </div>
+        <p className="mt-3 text-xs text-slate-400">Sem spam. Você pode sair quando quiser.</p>
+      </div>
+    </div>
+  );
+};
+
+export default LoginGateModal;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../lib/supabaseClient';
 import { ensureProfile } from '../lib/ensureProfile';
 import type { Session, User, AuthChangeEvent } from '@supabase/supabase-js';
 import mixpanel from '../lib/mixpanel';
+import { clearGuestStorage } from '../hooks/useGuestGate';
 
 interface AuthContextType {
   user: User | null;
@@ -92,6 +93,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setLoading(false);
 
       if (session?.user) {
+        clearGuestStorage();
         ensureProfile(session.user).catch((err) =>
           console.error('Erro ao garantir perfil durante getSession:', err),
         );
@@ -117,6 +119,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         }
 
         if (session?.user && (event === 'SIGNED_IN' || event === 'INITIAL_SESSION')) {
+          clearGuestStorage();
           syncMixpanelIdentity(session.user);
         }
 

--- a/src/hooks/useGuestGate.ts
+++ b/src/hooks/useGuestGate.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+
+import mixpanel from '../lib/mixpanel';
+
+export const GUEST_ID_KEY = 'eco.guest.id';
+export const GUEST_INTERACTION_COUNT_KEY = 'eco.guest.interactionCount';
+export const GUEST_INPUT_DISABLED_KEY = 'eco.guest.inputDisabled';
+const GUEST_GATE_TRACKED_KEY = 'eco.guest.gateTracked';
+const LIMIT = 6;
+
+const hasWindow = () => typeof window !== 'undefined';
+
+const safeGetItem = (key: string) => {
+  if (!hasWindow()) return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch (err) {
+    console.warn('[GuestGate] Falha ao ler localStorage', err);
+    return null;
+  }
+};
+
+const safeSetItem = (key: string, value: string) => {
+  if (!hasWindow()) return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (err) {
+    console.warn('[GuestGate] Falha ao salvar localStorage', err);
+  }
+};
+
+const safeRemoveItem = (key: string) => {
+  if (!hasWindow()) return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch (err) {
+    console.warn('[GuestGate] Falha ao remover localStorage', err);
+  }
+};
+
+export function clearGuestStorage() {
+  [
+    GUEST_ID_KEY,
+    GUEST_INTERACTION_COUNT_KEY,
+    GUEST_INPUT_DISABLED_KEY,
+    GUEST_GATE_TRACKED_KEY,
+  ].forEach((key) => safeRemoveItem(key));
+}
+
+export function useGuestGate(enabled: boolean) {
+  const [guestId, setGuestId] = useState<string | null>(null);
+  const [count, setCount] = useState(0);
+  const [inputDisabled, setInputDisabled] = useState(false);
+
+  const reachedLimit = count >= LIMIT;
+  const guestIdRef = useRef<string | null>(null);
+  const gateTrackedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setGuestId(null);
+      setCount(0);
+      setInputDisabled(false);
+      gateTrackedRef.current = false;
+      return;
+    }
+
+    let id = safeGetItem(GUEST_ID_KEY);
+    if (!id) {
+      id = uuid();
+      safeSetItem(GUEST_ID_KEY, id);
+      mixpanel.track('guest_start', { guestId: id });
+    }
+    setGuestId(id);
+    guestIdRef.current = id;
+
+    const storedCountRaw = safeGetItem(GUEST_INTERACTION_COUNT_KEY);
+    const storedCount = storedCountRaw ? Number(storedCountRaw) : 0;
+    const validCount = Number.isFinite(storedCount) ? Math.max(0, Math.floor(storedCount)) : 0;
+    setCount(validCount);
+
+    const disabled = safeGetItem(GUEST_INPUT_DISABLED_KEY) === '1';
+    setInputDisabled(disabled || validCount >= LIMIT);
+
+    gateTrackedRef.current = safeGetItem(GUEST_GATE_TRACKED_KEY) === '1' || disabled || validCount >= LIMIT;
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    safeSetItem(GUEST_INTERACTION_COUNT_KEY, String(count));
+
+    if (count >= LIMIT) {
+      safeSetItem(GUEST_INPUT_DISABLED_KEY, '1');
+      setInputDisabled(true);
+      if (!gateTrackedRef.current && guestIdRef.current) {
+        gateTrackedRef.current = true;
+        safeSetItem(GUEST_GATE_TRACKED_KEY, '1');
+        mixpanel.track('guest_gate_shown', {
+          guestId: guestIdRef.current,
+          count,
+        });
+      }
+    } else {
+      safeRemoveItem(GUEST_INPUT_DISABLED_KEY);
+      safeRemoveItem(GUEST_GATE_TRACKED_KEY);
+      gateTrackedRef.current = false;
+      setInputDisabled(false);
+    }
+  }, [count, enabled]);
+
+  const registerUserInteraction = useCallback(() => {
+    if (!enabled) return;
+    setCount((prev) => {
+      if (prev >= LIMIT) return prev;
+      const next = prev + 1;
+      if (guestIdRef.current) {
+        mixpanel.track('guest_message', {
+          guestId: guestIdRef.current,
+          count: next,
+        });
+      }
+      return next;
+    });
+  }, [enabled]);
+
+  const resetGuest = useCallback(() => {
+    clearGuestStorage();
+    guestIdRef.current = null;
+    gateTrackedRef.current = false;
+    setGuestId(null);
+    setCount(0);
+    setInputDisabled(false);
+  }, []);
+
+  return useMemo(
+    () => ({
+      guestId,
+      count,
+      limit: LIMIT,
+      inputDisabled,
+      reachedLimit,
+      registerUserInteraction,
+      resetGuest,
+    }),
+    [count, guestId, inputDisabled, reachedLimit, registerUserInteraction, resetGuest],
+  );
+}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -8,7 +8,7 @@ import { useChat } from '../contexts/ChatContext';
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const { signOut } = useAuth();
+  const { signOut, user } = useAuth();
   const { clearMessages } = useChat();
 
   const pageTitle =
@@ -31,7 +31,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
       <Header
         title={pageTitle}
         variant="auto"
-        onLogout={handleLogout}   // <<<<<< essencial para o botão aparecer
+        onLogout={user ? handleLogout : undefined}
       />
 
       {/* Espaçamento controlado pelas CSS vars definidas no Header. */}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "rewrites": [
+    { "source": "/api/(.*)", "destination": "https://ecobackend888.onrender.com/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- allow the /chat route to load without authentication and show a login gate modal after six guest interactions
- add a reusable guest gate hook plus modal, integrate guest analytics, and adapt the chat stream logic for guest sessions
- update the Eco API helper and tests to send guest headers and payload metadata
- route API traffic through same-origin rewrites so guest chats avoid browser CORS blocks

## Testing
- npm run test -- src/api/__tests__/ecoApi.test.ts
- npm run test -- src/pages/__tests__/ChatPage.typingIndicator.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e56ab43dc0832599fa732e1fe5cae7