### PR TITLE
Handle guest unauthorized chat errors

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -90,6 +90,9 @@ const ChatPage: React.FC = () => {
     isAtBottom,
     isGuest,
     guestId: guestGate.guestId || undefined,
+    onUnauthorized: () => {
+      setLoginGateOpen(true);
+    },
   });
 
   const handleSendMessage = useCallback(


### PR DESCRIPTION
## Summary
- add a typed EcoApiError that surfaces HTTP statuses from /ask-eco failures
- show a friendly login prompt when guest chat requests return 401 by triggering the login gate

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e57b2196c48325b2173b77f7cbb066